### PR TITLE
A2dev master

### DIFF
--- a/acqu_user/root/macros/gainc_corrCB/IMggAll_vs_runnr.C
+++ b/acqu_user/root/macros/gainc_corrCB/IMggAll_vs_runnr.C
@@ -1,0 +1,238 @@
+#include "TH1.h"
+#include "TH2.h"
+#include "TROOT.h"
+#include "TFile.h"
+#include "TF1.h"
+#include "TLegend.h"
+#include "TCanvas.h"
+#include "TColor.h"
+#include "TMath.h"
+#include "TChain.h"
+#include "TProfile.h"
+#include "TNtuple.h"
+#include <sstream>
+#include <iostream>
+#include <fstream>
+
+using namespace std;
+
+void set_plot_style()
+{
+    const Int_t NRGBs = 5;
+    const Int_t NCont = 255;
+
+    Double_t stops[NRGBs] = { 0.00, 0.34, 0.61, 0.84, 1.00 };
+    Double_t red[NRGBs]   = { 0.00, 0.00, 0.87, 1.00, 0.51 };
+    Double_t green[NRGBs] = { 0.00, 0.81, 1.00, 0.20, 0.00 };
+    Double_t blue[NRGBs]  = { 0.51, 1.00, 0.12, 0.00, 0.00 };
+    TColor::CreateGradientColorTable(NRGBs, stops, red, green, blue, NCont);
+    gStyle->SetNumberContours(NCont);
+}
+
+void Fit(TH1* h, Double_t& outPos, Double_t& outFWHM)
+{
+    // Perform fit.
+    
+    Char_t tmp[256];
+
+    Double_t x1 = 50;
+    Double_t x2 = 300;
+
+    TF1* func = new TF1("func", "gaus(0)+pol2(3)", x1, x2);
+    func->SetParameters(h->GetMaximum(), 135, 8, 1, 1, 0.1, 0.1);
+    func->SetLineColor(kBlue);
+    func->SetParLimits(1, 128, 143);
+    func->SetParLimits(2, 5, 20);
+    h->Fit(func, "RBQO");
+    
+    // get position and FWHM
+    Double_t fPi0Pos = func->GetParameter(1);
+    outPos = fPi0Pos;
+    outFWHM = 2.35*func->GetParameter(2);
+
+    // indicator line
+    TLine line;
+    line.SetLineWidth(2);
+    line.SetX1(fPi0Pos);
+    line.SetX2(fPi0Pos);
+    line.SetY1(0);
+    line.SetY2(h->GetMaximum());
+
+    TF1* fBG = new TF1("funcBG", "pol2", x1, x2);
+    for (Int_t i = 0; i < 3; i++) fBG->SetParameter(i, func->GetParameter(3+i));
+   // for (Int_t i = 0; i < 6; i++) fBG->SetParameter(i, func->GetParameter(3+i));
+    fBG->SetLineColor(kRed);
+
+	delete func;
+	delete fBG;
+}
+
+// create a new histogram- IM(gg) and Eg as function of a run number
+// For each run number: get for each detector element average peak position and average energy. Fill upp ntuples
+// When all runs have been looped through, plot as function of detector nr, 
+void IMggAll_vs_runnr()
+{
+
+
+	string path = "/home/adlarson/data2014.07/CaLib/iter4/";
+
+	TString pathtohist = "CaLib_CB_IM";
+	ostringstream s;
+	
+	ofstream prtofile;
+	prtofile.open("CB_gain_vs_det_vs_runnr4.dat");
+	ofstream prtofileav;
+	prtofileav.open("IMggAll_vs_runnr.dat");
+
+
+	int ifirst_runnr = 4952; 
+	int ilast_runnr = 5905;
+	int ibinlow = 0;
+	int ibinhigh = 720;
+
+// Creating 720 TH2F histograms which will contain the IM(gg) All versus detector nr.
+	TH2F** detnr = new TH2F*[720];
+	for (int i = 0; i < 720; i++)
+	{
+		detnr[i] = new TH2F( Form("detnr%03d", i), Form("detnr%03d", i), (ilast_runnr-ifirst_runnr + 20), ifirst_runnr-10, ilast_runnr+10, 400, 120., 150. );	
+	}
+
+
+	std::vector<int>	fileNumbers;
+	for (int irunnr = ifirst_runnr; irunnr <= ilast_runnr; irunnr++)
+	{
+		s << path << "Hist_CBTaggTAPS_" << irunnr << ".root";
+		TString file1 = s.str();
+		f = new TFile( file1 );
+		if(f->IsOpen())
+		{
+			fileNumbers.push_back(irunnr);
+			f->Close();
+		}
+		s.str("");
+	}
+
+
+
+
+	std::vector<int>::iterator it = fileNumbers.begin();
+	for( int irunnr = ifirst_runnr; irunnr <= ilast_runnr; irunnr++ )
+	{	
+		if( irunnr == *(it) &&  it != fileNumbers.end() )
+  		{
+  		
+	  		prtofile << *(it) << "\t" ;
+	  		prtofileav << *(it) << "\t" ;
+
+			TH2F* summedHist = new TH2F("summedHist", "summedHist", 500, 0, 1000, 720, 0, 720);
+			int count = 0;
+			std::cout << *(it) << std::endl;
+			for(int i=-2; i<3; i++)
+			{
+				if( (it+i) < fileNumbers.begin() ) continue;
+				if( (it+i) >= fileNumbers.end() )	continue;
+				
+				count++;
+				s << path << "Hist_CBTaggTAPS_" << *(it+i) << ".root";
+				TString file1 = s.str();
+				f = new TFile( file1 );
+				if(f->IsOpen())
+				{
+					TH2F *rec1 = (TH2F*)f->Get(pathtohist);
+					if(rec1)
+						summedHist->Add(rec1);
+					f->Close();
+				}
+				s.str("");
+			}
+				TH1F* prpi0all = (TH1F*)summedHist->ProjectionX( "IM(#gamma#gamma) (MeV)", 0, 720)->Clone();
+				if( prpi0all->Integral() == 0 ) 
+				{
+					std::cout << "sth is wrong in run " << (*it) <<  std::endl;
+				}	
+				Double_t mean[2];
+//				prpi0all->Rebin(2);
+				Fit(prpi0all, mean[0], mean[1]);
+				prtofileav << std::setprecision(5) << mean[0] << "\n" ;
+				for( int ibn = ibinlow; ibn < ibinhigh; ibn++)
+				{
+					
+					TH1F* prpi0av = (TH1F*)summedHist->ProjectionX( "IM(#gamma#gamma) (MeV)", ibn+1, ibn+1)->Clone();
+
+				// insert the average over the full peak projection here
+				if( prpi0av->Integral() == 0 ) 
+				{
+
+	//				std::cout << "sth is wrong in run " << (*it) << " element number " << ibn <<  std::endl;
+					detnr[ibn]->Fill( *(it), 145.00 );
+					prtofile << std::setprecision(5) << "1.0000" << "\t" ;
+					
+				}
+				else
+				{
+					Double_t help[2];
+//					prpi0av->Rebin(2);
+					Fit(prpi0av, help[0], help[1]);
+				
+					if( (help[0] > 128.5) && (help[0] < 142.0) )
+					{	
+
+						detnr[ibn]->Fill( *(it), help[0] );
+						prtofile << std::setprecision(5) <<	Double_t( (134.9766*mean[0])/(help[0]*help[0]) ) << "\t" ;					
+					}
+					else
+					{
+						detnr[ibn]->Fill( *(it), 145.00 );
+						prtofile << std::setprecision(5) << "1.0000" << "\t" ;
+					}
+
+					if(prpi0av) delete prpi0av;
+				}
+								
+			}
+
+			prtofile << "\n" ;
+			if(summedHist) delete summedHist;
+			++it;
+		}
+		else
+		{
+			prtofile << irunnr << "\t" ;
+	  		prtofileav << irunnr  << "\t" ;
+	  		prtofileav << std::setprecision(5) << 134.9766 << "\n" ;
+	  		for( int k = 0; k < 720 ; k++ )
+	  		{
+	  			prtofile << std::setprecision(5) << "1.0000" << "\t" ;
+	  		}
+	  		prtofile << "\n" ;
+	  	}
+
+	}
+
+	prtofile.close();
+	prtofileav.close();
+
+	// Draws the histograms for all detector elements of floating average vs run number;  
+	int nCanvas = 45;
+	TCanvas** CCAC = new TCanvas*[nCanvas];
+	for (int i = 0; i < nCanvas; i++)
+	{
+		CCAC[i] = new TCanvas(Form("CCAC%02d", i), Form("CCAC%02d", i), 200, 10, 1000, 700);
+		CCAC[i]->SetFillColor(18);
+		CCAC[i]->Divide(4,4);
+		for( int k = 1; k <= 16; k++)
+		{
+			int inr = 720 - (k + 16*i);
+		//	int inr = (k + 16*i);
+			CCAC[i]->cd(17-k);
+			gPad->SetGridx();
+			gPad->SetGridy();
+			detnr[inr]->Draw("BOX");
+		}
+		CCAC[i]->SaveAs(Form("iter4_%02d.eps", i));
+	}
+	for(int i = 0; i < nCanvas; i++)
+		delete CCAC[i];
+	delete CCAC;
+	exit(0);
+}

--- a/acqu_user/root/macros/gainc_corrCB/mergecorr.C
+++ b/acqu_user/root/macros/gainc_corrCB/mergecorr.C
@@ -1,0 +1,125 @@
+#include <iostream>
+#include <fstream>
+#include <sstream>
+#include <string>
+#include <iomanip>      // std::setprecision
+#include <vector>
+#include <stdlib.h>
+#include <iomanip>      // std::setprecision
+
+int main()
+{
+//g++ mergecorr.C -o merge --std=c++11
+
+
+// This part is to get a list of all the run numbers in the gain correction files, i.e. the first element in each line
+	std::ifstream file1("/home/adlarson/data2014.07/macros/gaincorr/CB_gain_vs_det_vs_runnrit3.dat");		// path to first gain correction file 
+	std::ifstream file2("/home/adlarson/data2014.07/macros/gaincorr/gain_vs_det_vs_runnr_merged2.dat");		// path to second gain correction file 
+	std::string   line;
+	int irun;
+	const unsigned int start = 4952;
+	const unsigned int end = 5906;
+	double gain;
+	std::vector<int> f1;
+	std::vector<int> f2;
+
+	while(std::getline(file1, line))
+	{
+		std::stringstream ss;
+		ss << line;
+		irun = atoi(ss.str().c_str());  // atoi only reads everything from a string until a non-integer type occurs
+		f1.push_back(irun);
+
+	}
+	while(std::getline(file2, line))
+	{
+		std::stringstream ss;
+		ss << line;
+		irun = atoi(ss.str().c_str());
+		f2.push_back(irun);
+	}
+
+
+
+	auto it1 = f1.begin();
+	auto it2 = f2.begin();
+	std::ifstream in1("/home/adlarson/data2014.07/macros/gaincorr/CB_gain_vs_det_vs_runnrit3.dat");		// path to first gain correction fil
+	std::ifstream in2("/home/adlarson/data2014.07/macros/gaincorr/gain_vs_det_vs_runnr_merged2.dat");	// path to second gain correction file 
+	std::string line1, line2;
+	double gain1, gain2;
+	std::string buffer1, buffer2;
+
+	std::ofstream out;
+	out.open("/home/adlarson/data2014.07/macros/gaincorr/gain_vs_det_vs_runnr_merged3.dat");
+
+	
+	if (*it1 < start || *it2 < start) {
+		fprintf(stderr, "ERROR: start value %d is greater than run number %d|%d in file 1|2\n", start, *it1, *it2);
+		return 1;
+	}
+
+	for (unsigned int i = start; i <= end; i++) {
+		if (*it1 == i && *it2 == i) 
+		{
+			if (std::getline(in1, line1) && std::getline(in2, line2)) {
+				out << i << '\t';
+				std::stringstream ss1, ss2;
+
+				
+				// now we have the whole lines corresponding to runnumber i in lineX
+				ss1 << line1;
+				ss2 << line2;
+				std::getline(ss1, buffer1, '\t');
+				std::getline(ss2, buffer2, '\t');
+				while (std::getline(ss1, buffer1, '\t') && std::getline(ss2, buffer2, '\t')) {
+					out << std::fixed << std::setprecision(5) << std::stod(buffer1)*std::stod(buffer2) << '\t';
+				}
+				out << '\n';
+				++it1;
+				++it2;
+			} else
+				fprintf(stderr, "WARNING: no line to runnumber %d existing!\nThis should not happen!", i);
+		} 
+		else if (*it1 == i) 
+		{
+				out << i << '\t';
+				std::stringstream ss1;
+				// now we have the whole lines corresponding to runnumber i in lineX
+				ss1 << line1;
+				std::getline(ss1, buffer1, '\t');
+				//int j = 1;
+				while (std::getline(ss1, buffer1, '\t')) {
+					out << std::fixed << std::setprecision(5) << std::stod(buffer1) << '\t';
+				}
+				out << '\n';
+				++it1;
+		}
+		else if (*it2 == i) 
+		{
+				out << i << '\t';
+				std::stringstream ss2;
+				// now we have the whole lines corresponding to runnumber i in lineX
+				ss2 << line2;
+				std::getline(ss2, buffer2, '\t');
+				while (std::getline(ss2, buffer2, '\t')) {
+					out << std::fixed << std::setprecision(5) << std::stod(buffer2) << '\t';
+				}
+				out << '\n';
+				++it2;
+		} 
+		else 
+		{
+			out << i << '\t';
+			for(int k = 0; k < 720; k++)
+			{
+				out << std::fixed << std::setprecision(5) << "1.00000" << '\t';	
+			}
+			out << '\n';
+		}
+	}
+
+	out.close();
+
+	return 0;
+
+}

--- a/acqu_user/root/src/TA2AccessSQL.cc
+++ b/acqu_user/root/src/TA2AccessSQL.cc
@@ -19,7 +19,7 @@
 
 //______________________________________________________________________________
 TA2AccessSQL::TA2AccessSQL(const char* name, TA2Analysis* analysis)	: TA2Physics(name, analysis), 
-  CBEnergyPerRunCorrection(false),
+  CBEnergyPerRunCorrection(false), TAPSEnergyPerRunCorrection(false),
   fCaLibReader(0)
 {
   // command-line recognition for SetConfig()
@@ -221,6 +221,7 @@ void TA2AccessSQL::SetConfig(Char_t* line, Int_t key)
   case ESQL_CALIB_CBENERGY_PER_RUN:
   {  
     Char_t tmp[128];
+    Bool_t file_found = 0;
     
     printf("try to enable CBEnergy correction per Run\n");
     
@@ -240,25 +241,133 @@ void TA2AccessSQL::SetConfig(Char_t* line, Int_t key)
         printf("   or comment it out. Then no CBEnergy Calibration per Run is done.\n\n");
         exit(1);
       }
-      Int_t 		num;
-      Double_t 	val[4];
-      while(!feof(f))
+
+      ifstream  stream;
+      stream.open(tmp);
+      std::vector<double> gainsCB;
+      gainsCB.resize(0);
+
+      while( (!feof(f)) && (!file_found) )
       {
-        if (fscanf(f, "%d %lf %lf %lf %lf\n", &num, &val[0], &val[1], &val[2], &val[3]) == 5) 
-        {
-          if(num == fRunNumber)
-          {
-            CBEnergyPerRunCorrection		= true;
-            CBEnergyPerRunCorrectionFactor	= val[0];
-            printf("CBEnergy correction factor for run %d is %lf with error %lf\n", fRunNumber, CBEnergyPerRunCorrectionFactor, val[1]);
-            break;
+          std::string   line;
+          std::getline(stream, line);
+
+          //std::string   runnr(line.substr(0,5));
+          std::stringstream s_line(line);
+          int runnumber;
+
+          if(!(s_line >> runnumber)) {
+              std::cerr << "Cannot parse runnumber" << std::endl;
+              continue;
           }
-        }
+          if(runnumber == fRunNumber){
+
+            CBEnergyPerRunCorrection = true;
+            double gain;
+            gainsCB.reserve(720);
+            while(s_line >> gain) {
+              gainsCB.push_back(gain);
+            }
+            file_found = 1;
+          }
+          else
+            continue;
       }
       fclose(f);
+      stream.close();
+      if(file_found)
+      {
+          for(UInt_t i=0; i < gainsCB.size(); i++)
+          {
+            CBEnergyPerRunCorrectionFactor[i] = gainsCB[i];
+            std::cout << gainsCB[i] << "\n";
+          }
+      }
+      else  //( ifound == 0 )
+      {
+        printf("Could not find gaincorrections for run %d.\n", fRunNumber);
+        for(int i=0; i<720; i++)
+            CBEnergyPerRunCorrectionFactor[i]= 1.0;
+        break;
+      }
       break;
     }
   }
+  case ESQL_CALIB_TAPSENERGY_PER_RUN:
+  {
+      Char_t tmp[128];
+      Bool_t file_found = 0;
+
+      printf("try to enable TAPS Energy correction per Run\n");
+      if (sscanf(line, "%s", tmp) == 1)
+      {
+        FILE*	f = fopen(tmp,"r");
+        if(!f)
+        {
+          Char_t tmp2[140];
+          sprintf(tmp2,"data/%s",tmp);
+          f = fopen(tmp2,"r");
+        }
+        if(!f)
+        {
+          printf("\nERROR: could not open %s as calibration per Run file! --> exiting\n", tmp);
+          printf("   correct the filename after the 'Use-CaLib-TAPSEnergyPerRun:' keyword in the physics class config file\n");
+          printf("   or comment it out. Then no TAPSEnergy Calibration per Run is done.\n\n");
+          exit(1);
+        }
+
+        ifstream  stream;
+        stream.open(tmp);
+        std::vector<double> gainsTAPS;
+        gainsTAPS.resize(0);
+
+        while( (!feof(f)) && (!file_found) )
+        {
+            std::string   line;
+            std::getline(stream, line);
+
+            std::stringstream s_line(line);
+            int runnumber;
+
+            if(!(s_line >> runnumber)) {
+                std::cerr << "Cannot parse runnumber" << std::endl;
+                continue;
+            }
+            if(runnumber == fRunNumber){
+
+              TAPSEnergyPerRunCorrection = true;
+              double gain;
+              gainsTAPS.reserve(438);
+              while(s_line >> gain) {
+                gainsTAPS.push_back(gain);
+              }
+              file_found = 1;
+            }
+            else
+              continue;
+        }
+        fclose(f);
+        stream.close();
+        if(file_found)
+        {
+            for(UInt_t i=0; i < gainsTAPS.size(); i++)
+            {
+              TAPSEnergyPerRunCorrectionFactor[i] = gainsTAPS[i];
+  //            std::cout << gainsTAPS[i] << "\n";
+            }
+        }
+        else  //( ifound == 0 )
+        {
+          printf("Could not find gaincorrections for run %d.\n", fRunNumber);
+          for(int i=0; i<438; i++)
+              TAPSEnergyPerRunCorrectionFactor[i]= 1.0;
+          break;
+        }
+        break;
+      }
+    }
+
+
   default:
   {
     // default main apparatus SetConfig()
@@ -475,14 +584,24 @@ void TA2AccessSQL::PostInit()
   
   if(fNaI && CBEnergyPerRunCorrection)
   {
+    //printf("gain after calib:		%lf\n", fNaI->GetElement(10)->GetA1());
     for(UInt_t i=0; i<fNaI->GetNelement(); i++)
-      fNaI->GetElement(i)->SetA1(CBEnergyPerRunCorrectionFactor * (fNaI->GetElement(i)->GetA1()));
-    printf("gain after calib:		%lf\n", fNaI->GetElement(10)->GetA1());
-    
-    for(UInt_t i=0; i<fNaI->GetNelement(); i++)
-      fNaI->GetElement(i)->SetA1(CBEnergyPerRunCorrectionFactor * (fNaI->GetElement(i)->GetA1()));
-    printf("gain after correction:	%lf\n", fNaI->GetElement(10)->GetA1());    
+    {
+        fNaI->GetElement(i)->SetA1(CBEnergyPerRunCorrectionFactor[i] * (fNaI->GetElement(i)->GetA1()));
+    }
+    //printf("gain after correction:	%lf\n", fNaI->GetElement(10)->GetA1());
   }
+  if(fBaF2PWO && TAPSEnergyPerRunCorrection)
+  {
+//      for( UInt_t i = 0; i < fBaF2PWO->GetNelement(); i++ )
+//    printf("gain after calib:		%lf\n", fBaF2PWO->GetElement(10)->GetA1());
+    for(UInt_t i=0; i<fBaF2PWO->GetNelement(); i++)
+    {
+        fBaF2PWO->GetElement(i)->SetA1(TAPSEnergyPerRunCorrectionFactor[i] * (fBaF2PWO->GetElement(i)->GetA1()));
+    }
+    //printf("gain after correction:	%lf\n", fNaI->GetElement(10)->GetA1());
+  }
+
 }
 
 void TA2AccessSQL::LoadVariable()

--- a/acqu_user/root/src/TA2AccessSQL.h
+++ b/acqu_user/root/src/TA2AccessSQL.h
@@ -41,7 +41,9 @@ enum {
   ESQL_CALIB_TAPS,
   ESQL_CALIB_PID,
   ESQL_CALIB_VETO,
-  ESQL_CALIB_CBENERGY_PER_RUN
+  ESQL_CALIB_CBENERGY_PER_RUN,
+  ESQL_CALIB_TAPSENERGY_PER_RUN,
+  ESQL_CALIB_TAPS_TOF
 };
 
 static const Map_t AccessSQLConfigKeys[] = {
@@ -53,6 +55,8 @@ static const Map_t AccessSQLConfigKeys[] = {
   {"Use-CaLib-PID:"                , ESQL_CALIB_PID},                      // key for CaLib PID configuration
   {"Use-CaLib-Veto:"               , ESQL_CALIB_VETO},                     // key for CaLib Veto configuration
   {"Use-CaLib-CBEnergyPerRun:"     , ESQL_CALIB_CBENERGY_PER_RUN},         // key for CaLib CBEnergy per Run configuration
+  {"Use-CaLib-TAPSEnergyPerRun:"   , ESQL_CALIB_TAPSENERGY_PER_RUN},       // key for CaLib TAPSEnergy per Run configuration
+  {"Use-CaLib-TAPS-TOF:"           , ESQL_CALIB_TAPS_TOF},                 // key for CaLib CBEnergy per Run configuration
   // Termination
   {NULL        , -1           }
 };
@@ -64,7 +68,10 @@ class TA2AccessSQL : public TA2Physics
 private:
   
   Bool_t			CBEnergyPerRunCorrection;
-  Double_t		CBEnergyPerRunCorrectionFactor;
+  Double_t		CBEnergyPerRunCorrectionFactor[720];
+
+  Bool_t			TAPSEnergyPerRunCorrection;
+  Double_t		TAPSEnergyPerRunCorrectionFactor[438];
   
   void	LoadDetectors(TA2DataManager* parent, Int_t depth);
   void 	ApplyCaLib();


### PR DESCRIPTION
Modifications to TA2AccessSQL.cc and TA2AccessSQL.h used to read in and apply gain corrections for CB and TAPS.

In addition two macros have been added to path macros/gainc_corrCB. The details of how to use this macro and implement gain corrections are found in  

http://wwwa2.kph.uni-mainz.de/intern/daqwiki/analysis/tutorials/calib/time_dependent_gain_corrections