### PR TITLE
Update of TA2LinearPolEpics and online monitor

### DIFF
--- a/acqu_core/AcquRoot/src/TA2Ladder.h
+++ b/acqu_core/AcquRoot/src/TA2Ladder.h
@@ -51,7 +51,7 @@ enum { EMaxRandWindows = 16 };
 
 class TA2Ladder : public TA2Detector {
 
-private:
+ private:
  protected:
   HitD2A_t** fTrigger;         	// Trigger info array (only if separate trig)
   UInt_t* fTrigg;              	// Trigger info for each each hit
@@ -153,6 +153,22 @@ public:
   Bool_t IsTimeWindows(){return fIsTimeWindows;}
   Bool_t IsFence(){ return fIsFence; }
   Bool_t IsMicro(){ return fIsMicro; }
+
+  
+  UInt_t* fScalerPromptIndex;            // local prompt scalers indices
+  UInt_t* fScalerPromptCurr;             // local prompt scalers current buffer
+  Double_t* fScalerPromptAcc;            // local prompt scalers accumulated buffer
+  UInt_t* fScalerRandIndex;              // local rand scalers indices
+  UInt_t* fScalerRandCurr;               // local rand scalers current buffer
+  Double_t* fScalerRandAcc;              // local rand scalers accumulated buffer
+  
+  UInt_t* GetScalerPromptIndex(){ return fScalerPromptIndex; }       // local prompt scalers
+  UInt_t* GetScalerPromptCurr(){ return fScalerPromptCurr; }         // local prompt scalers
+  Double_t* GetScalerPromptAcc(){ return fScalerPromptAcc; }         // local prompt scalers
+  UInt_t* GetScalerRandIndex(){ return fScalerRandIndex; }       // local rand scalers
+  UInt_t* GetScalerRandCurr(){ return fScalerRandCurr; }         // local rand scalers
+  Double_t* GetScalerRandAcc(){ return fScalerRandAcc; }         // local rand scalers
+  
   ClassDef(TA2Ladder,1)
 };
 

--- a/acqu_user/root/macros.online/CheckLinPol.C
+++ b/acqu_user/root/macros.online/CheckLinPol.C
@@ -1,98 +1,333 @@
 void CheckLinPol(TCanvas *canvLinPol) {
-	if(canvLinPol==NULL) {
-		return;
-	}
+  if(canvLinPol==NULL) {
+    return;
+  }
  
-	//gStyle->SetOptFit(1);
-	//gStyle->SetOptStat(0);
-	canvLinPol->Range(-79.0074,-0.373242,79.3233,0.359577);
-	canvLinPol->SetFillColor(10);
-	canvLinPol->SetFillStyle(4000);
-	canvLinPol->SetBorderSize(0);
-	canvLinPol->SetFrameFillColor(10);
-	canvLinPol->SetFrameFillStyle(0);
-	canvLinPol->SetBottomMargin(0.12);
-	canvLinPol->SetTopMargin(0.03);
-	//canvLinPol->SetStatFormat("5.3g");
+  //gStyle->SetOptFit(1);
+  //gStyle->SetOptStat(0);
+  canvLinPol->Range(-79.0074,-0.373242,79.3233,0.359577);
+  canvLinPol->SetFillColor(10);
+  canvLinPol->SetFillStyle(4000);
+  canvLinPol->SetBorderSize(0);
+  canvLinPol->SetFrameFillColor(10);
+  canvLinPol->SetFrameFillStyle(0);
+  canvLinPol->SetBottomMargin(0.12);
+  canvLinPol->SetTopMargin(0.03);
+  //canvLinPol->SetStatFormat("5.3g");
 
-	TA2LinearPol* pLP = (TA2LinearPol*)(gAN->GetChild("LinPol"));
+  TA2LinearPolEpics* pLP = (TA2LinearPolEpics*)(gAN->GetChild("LinPol"));
 
-	char* hnames[] = {"LinPol_Incoherent","LinPol_Coherent","LinPol_CoherentPara","LinPol_CoherentPerp","LinPol_EnhancementPara","LinPol_EnhancementPerp","LinPol_CohEdgeEnergy"};
+  char* hnames[] = {"LinPol_Incoherent",			  
+		    "LinPol_Coherent",			  
+		    "LinPol_CoherentPara",
+		    "LinPol_CoherentPerp",
+		    "LinPol_Enhancement",
+		    "LinPol_EnhancementPara",
+		    "LinPol_EnhancementPerp",
+		    "LinPol_CohEdge",
+		    "LinPol_CohEdgePara",
+		    "LinPol_CohEdgePerp",
+		    "LinPol_GatedIncoherent",
+		    "LinPol_GatedCoherent",
+		    "LinPol_GatedCoherentPara",
+		    "LinPol_GatedCoherentPerp",
+		    "LinPol_GatedCurrEnh",
+		    "LinPol_GatedCurrEnhPara",
+		    "LinPol_GatedCurrEnhPerp",
+		    "LinPol_CohEdgeGated",
+		    "LinPol_CohEdgeGatedPara",
+		    "LinPol_CohEdgeGatedPerp",
+		    "LinPol_PolTableEnh",
+		    "LinPol_PolTablePol"};
 
-	TLatex *texPARA= new TLatex(0.63,0.85,"PARA");;
-	texPARA->SetNDC();
-	texPARA->SetTextColor(2);
-	TLatex *texPERP= new TLatex(0.63,0.8,"PERP");;
-	texPERP->SetNDC();
-	texPERP->SetTextColor(4);
+  TLatex *texPARA= new TLatex(0.63,0.85,"PARA");
+  texPARA->SetNDC();
+  texPARA->SetTextColor(2);
+  TLatex *texPERP= new TLatex(0.63,0.8,"PERP");
+  texPERP->SetNDC();
+  texPERP->SetTextColor(4);
+  TLatex *texAMO= new TLatex(0.63,0.75,"AMO");
+  texAMO->SetNDC();
+  texAMO->SetTextColor(3);
+  TLatex *texFree= new TLatex(0.45,0.85,"Free");
+  texFree->SetNDC();
+  TLine *LFree = new TLine(0.38,0.87,0.44,0.87);
+  LFree->SetNDC();
+  LFree->SetLineStyle(1);
+  TLatex *texGated= new TLatex(0.45,0.8,"Gated");
+  texGated->SetNDC();
+  texGated->SetLineStyle(2);
+  TLine *LGated = new TLine(0.38,0.82,0.44,0.82);
+  LGated->SetNDC();
+  LGated->SetLineStyle(2);
 
-	//canvLinPol->SetFillStyle(4000);
-	canvLinPol->Divide(2,3,0.01,0.01);
-	TH1F* his;
+  //canvLinPol->SetFillStyle(4000);
+  canvLinPol->Divide(3,3,0.01,0.01);
+  TH1F* his;
+  
+  //Para or perp?
+  Int_t mode=pLP->GetPolPlane();
+  //cout<<"Current mode "<<mode<<endl;
+  
+  //////////////////////////////////////////////////////
+  /////////LinPol_Incoherent
+  canvLinPol->cd(1);
+  his=(TH1F*)gROOT->Get(hnames[0]);
+  his->SetTitle("TA2LinearPolEpics::Incoherent");
+  his->SetStats(false);
+  his->SetFillColor(kBlue+2);
+  his->Draw("hist");
 
-	/////////LinPol_Incoherent
-	canvLinPol->cd(1);
-	his=(TH1F*)gROOT->Get(hnames[0]);
-	his->Draw();
+  /////////LinPol_Coherent/Para/Perp
+  canvLinPol->cd(2);
+  if(mode==0)
+    {
+      his=(TH1F*)gROOT->Get(hnames[2]);
+      his->SetStats(false);
+      his->SetLineColor(2);
+      his->SetTitle("TA2LinearPolEpics::Coherent");
+      his->SetFillColor(2);
+      his->Draw();
+      texPARA->Draw("hist");
+    }
+  else if (mode==1)
+    {
+      his=(TH1F*)gROOT->Get(hnames[3]);
+      his->SetStats(false);
+      his->SetLineColor(4);
+      his->SetTitle("TA2LinearPolEpics::Coherent");
+      his->SetFillColor(4);
+      his->Draw();
+      texPERP->Draw("hist");
+    }
+  else if (mode==2)
+    {
+      his=(TH1F*)gROOT->Get(hnames[1]);
+      his->SetStats(false);
+      his->SetLineColor(3);
+      his->SetTitle("TA2LinearPolEpics::Coherent");
+      his->SetFillColor(3);
+      his->Draw("hist");
+      texAMO->Draw();
+    }
+	
+  /////////LinPol_Enhancement/Para/Perp
+  canvLinPol->cd(3);
+  if(mode==0)
+    {
+      his=(TH1F*)gROOT->Get(hnames[5]);
+      his->SetStats(false);
+      his->SetLineColor(2);
+      his->SetTitle("TA2LinearPolEpics::Enhancement");
+      his->SetFillColor(2);
+      his->SetMinimum(50);
+      his->Draw("hist");
+      texPARA->Draw();
+    }
+  else if (mode==1)
+    {
+      his=(TH1F*)gROOT->Get(hnames[6]);
+      his->SetStats(false);
+      his->SetLineColor(4);
+      his->SetTitle("TA2LinearPolEpics::Enhancement");
+      his->SetFillColor(4);
+      his->SetMinimum(50);
+      his->Draw("hist");
+      texPERP->Draw();
+    }
+  else if (mode==2)
+    {
+      his=(TH1F*)gROOT->Get(hnames[4]);
+      his->SetStats(false);
+      his->SetLineColor(3);
+      his->SetTitle("TA2LinearPolEpics::Enhancement");
+      his->SetFillColor(3);
+      his->SetMinimum(50);
+      his->Draw("hist");
+      texAMO->Draw();
+    }
+  
+  /////////LinPol_GatedInc
+   canvLinPol->cd(4);
+  his=(TH1F*)gROOT->Get(hnames[10]);
+  his->SetStats(false);
+  his->SetTitle("TA2LinearPolEpics::GatedIncoherent");
+  his->SetFillColor(kBlue+2);
+  his->Draw("hist");
 
-	/////////LinPol_Coherent
-	canvLinPol->cd(2);
-	his=(TH1F*)gROOT->Get(hnames[1]);
-	his->Draw();
-	Int_t mode=pLP->GetGoniMode();//Para or perp?
-	//cout<<"Current mode "<<mode<<endl;
-	if(mode==1)
-		{
-			texPARA->Draw();
-			his->SetLineColor(2);
-		}
-	else if (mode==2)
-		{
-			texPERP->Draw();
-			his->SetLineColor(4);
-		}
+  /////////LinPol_GatedCoh/Para/Perp
+  canvLinPol->cd(5);
+  if(mode==0)
+    {
+      his=(TH1F*)gROOT->Get(hnames[12]);
+      his->SetStats(false);
+      his->SetLineColor(2);
+      his->SetTitle("TA2LinearPolEpics::GatedCoherent");
+      his->SetFillColor(2);
+      his->Draw("hist");
+      texPARA->Draw();
+    }
+  else if (mode==1)
+    {
+      his=(TH1F*)gROOT->Get(hnames[13]);
+      his->SetStats(false);
+      his->SetLineColor(4);
+      his->SetTitle("TA2LinearPolEpics::GatedCoherent");
+      his->SetFillColor(4);
+      his->Draw("hist");
+      texPERP->Draw();
+    }
+  else if (mode==2)
+    {
+      his=(TH1F*)gROOT->Get(hnames[11]);
+      his->SetStats(false);
+      his->SetLineColor(3);
+      his->SetTitle("TA2LinearPolEpics::GatedCoherent");
+      his->SetFillColor(3);
+      his->Draw("hist");
+      texAMO->Draw();
+    }
+	
+  /////////LinPol_GatedEnh/Para/Perp
+  canvLinPol->cd(6);
+  if(mode==0)
+    {
+      his=(TH1F*)gROOT->Get(hnames[15]);
+      his->SetStats(false);
+      his->SetLineColor(2);
+      his->SetLineStyle(1);
+      his->SetTitle("TA2LinearPolEpics::GatedEnhancement");
+      his->SetFillColor(2);
+      his->SetMinimum(50);
+      his->SetMaximum(350);
+      his->Draw("hist");
+      texPARA->Draw();
+    }
+  else if (mode==1)
+    {
+      his=(TH1F*)gROOT->Get(hnames[16]);
+      his->SetStats(false);
+      his->SetLineColor(4);
+      his->SetLineStyle(1);
+      his->SetTitle("TA2LinearPolEpics::GatedEnhancement");
+      his->SetFillColor(4);
+      his->SetMinimum(50);
+      his->SetMaximum(350);
+      his->Draw("hist");
+      texPERP->Draw();
+    }
+  else if (mode==2)
+    {
+      his=(TH1F*)gROOT->Get(hnames[14]);
+      his->SetStats(false);
+      his->SetLineColor(3);
+      his->SetLineStyle(1);
+      his->SetTitle("TA2LinearPolEpics::GatedEnhancement");
+      his->SetFillColor(3);
+      his->SetMinimum(50);
+      his->SetMaximum(350);
+      his->Draw("hist");
+      texAMO->Draw();
+    }
 
-	/////////LinPol_CoherentPara
-	canvLinPol->cd(3);
-	his=(TH1F*)gROOT->Get(hnames[2]);
-	his->SetLineColor(2);
-	his->Draw();
+  /////////LinPol_CohEdge
+  canvLinPol->cd(7);
+  if(mode==0)
+    {
+      his=(TH1F*)gROOT->Get(hnames[8]);
+      his->SetStats(false);
+      his->SetLineColor(2);
+      his->SetLineStyle(1);
+      his->SetMarkerStyle(21);
+      his->SetMarkerSize(0.5);
+      his->SetMarkerColor(2);
+      his->SetTitle("TA2LinearPolEpics::CohEdge");
+      his->Draw("pe1");
+      his->SetMarkerStyle(25);
+      his->SetMarkerSize(0.5);
+      his->SetMarkerColor(2);
+      his=(TH1F*)gROOT->Get(hnames[18]);
+      his->SetStats(false);
+      his->SetLineColor(2);
+      his->SetLineStyle(2);
+      
+      his->Draw("SAME,pe1");
 
-	/////////LinPol_CoherentPerp
-	canvLinPol->cd(4);
-	his=(TH1F*)gROOT->Get(hnames[3]);
-	his->SetLineColor(4);
-	his->Draw("");
+      LFree->Draw();
+      LGated->Draw();
+      texGated->Draw();
+      texFree->Draw();
+      texPARA->Draw();
+    }
+  else if (mode==1)
+    {
+      his=(TH1F*)gROOT->Get(hnames[9]);
+      his->SetStats(false);
+      his->SetLineColor(4);
+      his->SetLineStyle(1);
+      his->SetMarkerStyle(21);
+      his->SetMarkerSize(0.5);
+      his->SetMarkerColor(4);
+      his->SetTitle("TA2LinearPolEpics::CohEdge");
+      his->Draw("pe1");
 
-	/////////LinPol_EnhancementPara
-	canvLinPol->cd(5);
-	his=(TH1F*)gROOT->Get(hnames[4]);
-	his->SetLineColor(2);
+      his=(TH1F*)gROOT->Get(hnames[19]);
+      his->SetStats(false);
+      his->SetLineColor(4);
+      his->SetLineStyle(2);
+      his->SetMarkerStyle(25);
+      his->SetMarkerSize(0.5);
+      his->SetMarkerColor(4);
+      his->Draw("SAME,pe1");
 
-	if(his->Integral()){
-		his->Draw();
-		texPARA->Draw();
-	}
-	//////////LinPol_CoherentPerp
-	//canvLinPol->cd(6);
-	if(his->Integral()){
-		his=(TH1F*)gROOT->Get(hnames[5]);
-		his->SetLineColor(4);
-		his->Draw("same");
-		texPERP->Draw();
-	}
-	else{
-		his=(TH1F*)gROOT->Get(hnames[5]);
-		if(his->Integral()){
-			his->SetLineColor(4);
-			his->Draw("");
-			texPERP->Draw();
-		}
-	}
+      LFree->Draw();
+      LGated->Draw();
+      texGated->Draw();
+      texFree->Draw();
+      texPERP->Draw();
+    }
+  else if (mode==2)
+    {
+      his=(TH1F*)gROOT->Get(hnames[7]);
+      his->SetStats(false);
+      his->SetLineColor(3);
+      his->SetLineStyle(1);
+      his->SetMarkerStyle(21);
+      his->SetMarkerSize(0.5);
+      his->SetMarkerColor(3);
+      his->SetTitle("TA2LinearPolEpics::CohEdge");
+      his->Draw("pe1");
 
-	//////////LinPol_CoherentPerp
-	canvLinPol->cd(6);
-	his=(TH1F*)gROOT->Get(hnames[6]);
-	his->Draw("");
+      his=(TH1F*)gROOT->Get(hnames[17]);
+      his->SetStats(false);
+      his->SetLineColor(3);
+      his->SetLineStyle(2);
+      his->SetMarkerStyle(25);
+      his->SetMarkerSize(0.5);
+      his->SetMarkerColor(3);
+      his->Draw("SAME,pe1");
 
+      LFree->Draw();
+      LGated->Draw();
+      texGated->Draw();
+      texFree->Draw();
+      texAMO->Draw();
+    }
+  
+  /////////LinPol_PolTableEnh
+  canvLinPol->cd(8);
+  his=(TH1F*)gROOT->Get(hnames[20]);
+  his->SetStats(false);
+  his->SetTitle("TA2LinearPolEpics::PolTableEnh");
+  his->SetFillColor(kBlue+2);
+  his->Draw();
+	
+  /////////LinPol_PolTablePol
+  canvLinPol->cd(9);
+  his=(TH1F*)gROOT->Get(hnames[21]);
+  his->SetStats(false);
+  his->SetTitle("TA2LinearPolEpics::PolTablePol");
+  his->SetFillColor(kBlue+2);
+  his->Draw();
+	
 }

--- a/acqu_user/root/macros/ladderDump.C
+++ b/acqu_user/root/macros/ladderDump.C
@@ -1,0 +1,13 @@
+void ladderDump(char *file = "data/ladder_scalers.dat"){
+  FILE *fp;
+  
+    fp=fopen(file,"w");
+    fprintf(fp,"# 'F' must be included if file has three columns!\n");
+    fprintf(fp,"F\n");
+    fprintf(fp,"# Contents of current scaler buffer\n");
+    fprintf(fp,"# Channel\tContent\tGatedDifference\n");
+    for(int n=1;n<=352;n++){
+      fprintf(fp,"%d %10.1f %10.1f\n",n,FPD_ScalerAcc->GetBinContent(n),(FPD_ScalerPromptAcc->GetBinContent(n) - FPD_ScalerRandAcc->GetBinContent(n)));
+    }
+    fclose(fp);
+}


### PR DESCRIPTION
The new TA2LinearPolEpics class includes also the data from the pair spec. Various changes to track the coherent edge using data from the free running and gated tagger scalers.

Macro that is used to create the new amorphous reference.

Online Monitor to track coherent edge and polarisation. Is called by CheckGUI.C.
