### PR TITLE
MC calibration included

### DIFF
--- a/CaLib/config/config_MC_example.cfg
+++ b/CaLib/config/config_MC_example.cfg
@@ -6,7 +6,6 @@ File.Input.Rootfiles: /tmp/ARHistograms_CB_RUN.root
 # the following config keys are only needed to calibrate MC data
 File.Input.MC: 1
 File.MC.Directory: /path/to/root-files/
-File.MC.RunNumber: 999001
 
 ################################################################################
 # Log configuration                                                            #

--- a/CaLib/config/config_MC_example.cfg
+++ b/CaLib/config/config_MC_example.cfg
@@ -1,0 +1,270 @@
+################################################################################
+# File configuration                                                           #
+################################################################################
+
+File.Input.Rootfiles: /tmp/ARHistograms_CB_RUN.root
+# the following config keys are only needed to calibrate MC data
+File.Input.MC: 1
+File.MC.Directory: /path/to/root-files/
+File.MC.RunNumber: 999001
+
+################################################################################
+# Log configuration                                                            #
+################################################################################
+
+Log.Images:           /usr/users/werthm/src/ROOT/CaLib/images
+
+################################################################################
+# Database configuration                                                       #
+################################################################################
+
+DB.Host:        a2calib.online.a2.kph
+#DB.Host:        localhost
+#DB.Name:        CaLib_2004_01-2012_08
+#DB.Name:        CaLib_2012_10
+#DB.Name:        CaLib_2012_12
+#DB.Name:        CaLib_2013_02
+#DB.Name:        CaLib_2013_03-2013_07
+DB.Name:        CaLib_2013_10-Present
+DB.User:        calib
+DB.Pass:        blaster
+
+################################################################################
+# Number of detector elements                                                  #
+################################################################################
+
+Tagger.Elements: 48
+#TAPS.Elements: 384
+TAPS.Elements: 438
+Veto.Elements: 384
+
+################################################################################
+# Misc calibration configuration                                               #
+################################################################################
+
+# Target position
+Target.Position.Bins: 200
+Target.Position.Range: -10 10
+Target.Position.Histo.Fit.Name: CaLib_CB_IM_TargPos
+Target.Position.Histo.Fit.Xaxis.Range: 80 190
+Target.Position.Histo.Overview.Yaxis.Range: 0 20
+
+################################################################################
+# Tagger calibration configuration                                             #
+################################################################################
+
+# Time calibration
+#Tagger.Time.Histo.Fit.Name: CaLib_Tagger_Time
+#Tagger.Time.Histo.Fit.Name: CaLib_Tagger_Time_Neut
+Tagger.Time.Histo.Fit.Name: CaLib_Tagger_Time_Pi0
+Tagger.Time.Histo.Fit.Xaxis.Range: -5 5
+Tagger.Time.Histo.Overview.Yaxis.Range: -1 1
+
+################################################################################
+# CB calibration configuration                                                 #
+################################################################################
+
+# Energy calibration
+#CB.Energy.Histo.Fit.Name: CaLib_CB_IM
+CB.Energy.Histo.Fit.Name: CaLib_CB_IM_Neut
+CB.Energy.Histo.Fit.Xaxis.Range: 50 250
+CB.Energy.Histo.Overview.Yaxis.Range: 132 137
+
+# Quadratic energy correction
+CB.QuadEnergy.Histo.Fit.Name: CaLib_CB_Quad_IM
+CB.QuadEnergy.Histo.MeanE.Pi0.Name: CaLib_CB_Quad_Pi0_Mean_E
+CB.QuadEnergy.Histo.MeanE.Eta.Name: CaLib_CB_Quad_Eta_Mean_E
+CB.QuadEnergy.Histo.Fit.Pi0.IM.Xaxis.Range: 50 240
+CB.QuadEnergy.Histo.Fit.Pi0.IM.Rebin: 0
+CB.QuadEnergy.Histo.Fit.Eta.IM.Xaxis.Range: 300 700
+CB.QuadEnergy.Histo.Fit.Eta.IM.Rebin: 4
+CB.QuadEnergy.Histo.Fit.Pi0.MeanE.Xaxis.Range: 0 700
+CB.QuadEnergy.Histo.Fit.Eta.MeanE.Xaxis.Range: 0 700
+CB.QuadEnergy.Histo.Overview.Pi0.Yaxis.Range: 132 137
+CB.QuadEnergy.Histo.Overview.Eta.Yaxis.Range: 540 570
+
+# Time calibration
+#CB.Time.Histo.Fit.Name:  CaLib_CB_Time
+CB.Time.Histo.Fit.Name:  CaLib_CB_Time_Neut
+CB.Time.Histo.Fit.Xaxis.Range: -50 50
+CB.Time.Histo.Overview.Yaxis.Range: -1 1
+CB.Time.TDCGain: 0.11771
+
+# Rise time calibration
+CB.RiseTime.Histo.Fit.Name:  CaLib_CB_RiseTime
+CB.RiseTime.Histo.Fit.Xaxis.Range: -10 10
+CB.RiseTime.Histo.Overview.Yaxis.Range: -1 1
+
+# Time walk calibration
+CB.TimeWalk.Histo.Fit.Name: CaLib_CB_Walk_E_T
+CB.TimeWalk.Histo.Fit.Xaxis.Range: 0 250
+CB.TimeWalk.Fit.Delay: 0
+
+# LED calibration
+CB.LED.Histo.Fit.Name: CaLib_CB_LED_M2
+#CB.LED.Histo.Fit.Name: CaLib_CB_LED_M3
+CB.LED.Histo.Fit.Rebin: 2
+CB.LED.Histo.Fit.Xaxis.Range: 0 70
+CB.LED.Histo.Overview.Yaxis.Range: 0 100
+
+################################################################################
+# TAPS calibration configuration                                               #
+################################################################################
+
+# LG pedestal calibration
+TAPS.Ped.LG.ADCList: /usr/users/werthm/AcquRoot/acqu/acqu/data/Dec_07/TAPS/BaF2.dat
+#TAPS.Ped.LG.ADCList: /usr/users/werthm/AcquRoot/acqu/acqu/data/Feb_09/TAPS/BaF2_PWO.dat
+#TAPS.Ped.LG.ADCList: /usr/users/werthm/AcquRoot/acqu/acqu/data/May_09/TAPS/BaF2_PWO.dat
+TAPS.Ped.LG.Histo.Overview.Yaxis.Range: 90 115
+
+# SG pedestal calibration
+TAPS.Ped.SG.ADCList: /usr/users/werthm/AcquRoot/acqu/acqu/data/Dec_07/TAPS/BaF2.dat
+##TAPS.Ped.SG.ADCList: /usr/users/werthm/AcquRoot/acqu/acqu/data/Feb_09/TAPS/BaF2_PWO.dat
+#TAPS.Ped.SG.ADCList: /usr/users/werthm/AcquRoot/acqu/acqu/data/May_09/TAPS/BaF2_PWO.dat
+TAPS.Ped.SG.Histo.Overview.Yaxis.Range: 80 150
+
+# Veto pedestal calibration
+TAPS.Ped.Veto.ADCList: /usr/users/werthm/AcquRoot/acqu/acqu/data/Dec_07/TAPS/Veto.dat
+#TAPS.Ped.Veto.ADCList: /usr/users/werthm/AcquRoot/acqu/acqu/data/Feb_09/TAPS/Veto.dat
+#TAPS.Ped.Veto.ADCList: /usr/users/werthm/AcquRoot/acqu/acqu/data/May_09/TAPS/Veto.dat
+TAPS.Ped.Veto.Histo.Overview.Yaxis.Range: 80 150
+
+# LG energy calibration
+TAPS.Energy.LG.Histo.Fit.Name: CaLib_TAPS_IM_Neut_1CB_1TAPS
+#TAPS.Energy.LG.Histo.Fit.Name: CaLib_TAPS_IM_Neut_2TAPS
+#TAPS.Energy.LG.Histo.Fit.Name: CaLib_TAPS_IM_Neut
+TAPS.Energy.LG.Histo.Fit.Xaxis.Range: 50 250
+TAPS.Energy.LG.Histo.Overview.Yaxis.Range: 133 137
+
+# SG energy calibration
+TAPS.Energy.SG.Histo.Fit.Name: CaLib_TAPS_PSAR_PSAA_SM
+TAPS.Energy.SG.Histo.Fit.Xaxis.Range: 30 55
+TAPS.Energy.SG.Photon.Energy.Range.1: 0 50 
+TAPS.Energy.SG.Photon.Energy.Range.2: 500 600
+TAPS.Energy.SG.Histo.Overview.Yaxis.Range: 40 48
+
+# Quadratic energy correction
+TAPS.QuadEnergy.Histo.Fit.Name: CaLib_TAPS_Quad_IM
+TAPS.QuadEnergy.Histo.MeanE.Pi0.Name: CaLib_TAPS_Quad_Pi0_Mean_E
+TAPS.QuadEnergy.Histo.MeanE.Eta.Name: CaLib_TAPS_Quad_Eta_Mean_E
+TAPS.QuadEnergy.Histo.Fit.Pi0.IM.Xaxis.Range: 50 200
+TAPS.QuadEnergy.Histo.Fit.Pi0.IM.Rebin: 0
+TAPS.QuadEnergy.Histo.Fit.Eta.IM.Xaxis.Range: 300 700
+TAPS.QuadEnergy.Histo.Fit.Eta.IM.Rebin: 4
+TAPS.QuadEnergy.Histo.Fit.Pi0.MeanE.Xaxis.Range: 0 700
+TAPS.QuadEnergy.Histo.Fit.Eta.MeanE.Xaxis.Range: 0 900
+TAPS.QuadEnergy.Histo.Overview.Pi0.Yaxis.Range: 125 140
+TAPS.QuadEnergy.Histo.Overview.Eta.Yaxis.Range: 510 580
+
+# Time calibration
+#TAPS.Time.Histo.Fit.Name: CaLib_TAPS_Time
+TAPS.Time.Histo.Fit.Name: CaLib_TAPS_Time_Neut
+#TAPS.Time.Histo.Fit.Name: CaLib_TAPS_Time_Neut_IM_Cut
+TAPS.Time.Histo.Fit.Xaxis.Range: -3 3
+TAPS.Time.Histo.Overview.Yaxis.Range: -1 1
+
+# LED1 calibration
+TAPS.LED1.Histo.Norm.Name: CaLib_TAPS_LED_Norm
+TAPS.LED1.Histo.Fit.Name: CaLib_TAPS_LED_LED1
+#TAPS.LED1.Histo.Fit.Name: CaLib_TAPS_LED_M2
+#TAPS.LED1.Histo.Fit.Name: CaLib_TAPS_LED_M3
+TAPS.LED1.Histo.Fit.Xaxis.Range: 5 100
+TAPS.LED1.Histo.Fit.Rebin: 2
+TAPS.LED1.Histo.Overview.Yaxis.Range: 0 100
+
+# LED2 calibration
+TAPS.LED2.Histo.Norm.Name: CaLib_TAPS_LED_Norm
+TAPS.LED2.Histo.Fit.Name: CaLib_TAPS_LED_LED2
+#TAPS.LED2.Histo.Fit.Name: CaLib_TAPS_LED2_M2
+TAPS.LED2.Histo.Fit.Xaxis.Range: 5 100
+TAPS.LED2.Histo.Overview.Yaxis.Range: 0 150
+
+# CFD calibration
+#TAPS.CFD.ADCList: /usr/users/werthm/AcquRoot/acqu/acqu/data/Dec_07/TAPS/BaF2.dat
+#TAPS.CFD.ADCList: /usr/users/werthm/AcquRoot/acqu/acqu/data/Feb_09/TAPS/BaF2_PWO.dat
+TAPS.CFD.ADCList: /usr/users/werthm/AcquRoot/acqu/acqu/data/May_09/TAPS/BaF2_PWO.dat
+TAPS.CFD.E0.Set: 0
+TAPS.CFD.E1.Set: 0
+TAPS.CFD.Histo.Fit.Xaxis.Range: 80 180
+TAPS.CFD.Histo.Overview.Yaxis.Range: 0 20
+
+# PSA
+TAPS.PSA.Histo.Fit.Name: CaLib_TAPS_PSAR_PSAA
+TAPS.PSA.Histo.Fit.Xaxis.Range: 27 52.5
+TAPS.PSA.Histo.Fit.Yaxis.Range: 20 600
+TAPS.PSA.Fit.Delay: 100
+
+################################################################################
+# PID calibration configuration                                                #
+################################################################################
+
+# Phi calibration
+#PID.Phi.Histo.Fit.Name: CaLib_PID_CBPhi_ID_1Cryst
+PID.Phi.Histo.Fit.Name: CaLib_PID_CBPhi_ID
+PID.Phi.Histo.Fit.Xaxis.Range: -300 300
+#PID.Phi.Histo.Overview.Yaxis.Range: -200 200
+
+# Droop correction
+PID.Droop.Histo.Fit.Name: CaLib_PID_dE_E
+PID.Droop.Histo.Fit.Xaxis.Range: 0 600
+PID.Droop.Fit.Delay: 10
+PID.Droop.Fit.Range: 20 150
+PID.Droop.Fit.Interval: 4
+PID.Droop.Fit.Energy.Range: 80 90
+
+# Energy calibration
+PID.Energy.MC.File: $CALIB/data/MC_PID.root
+PID.Energy.Histo.MC.Name: pi0_proton_May_09
+PID.Energy.Histo.Fit.Name: CaLib_PID_dE_E
+PID.Energy.Histo.Fit.Xaxis.Range: 0 2000
+PID.Energy.Fit.Delay: 200
+PID.Energy.Fit.Range: 150 350
+PID.Energy.Fit.Interval: 50
+
+# Energy calibration (traditional method)
+PID.Energy.Trad.MC.File: $CALIB/data/MC_PID.root
+PID.Energy.Trad.Histo.MC.Name: pi-_proton
+PID.Energy.Trad.Histo.Fit.Name: CaLib_PID_dE_E
+PID.Energy.Trad.Histo.Fit.Xaxis.Range: 0 2000
+PID.Energy.Trad.Histo.Fit.Yaxis.Range: 0 20
+PID.Energy.Trad.Fit.Delay: 200
+PID.Energy.Trad.Fit.Range: 80 90
+
+# Time calibration
+PID.Time.Histo.Fit.Name:  CaLib_PID_Time
+PID.Time.Histo.Fit.Xaxis.Range: -10 10
+PID.Time.Histo.Overview.Yaxis.Range: -5 5
+PID.Time.TDCGain: 0.11771
+
+################################################################################
+# Veto calibration configuration                                               #
+################################################################################
+
+# Correlation
+Veto.Correlation.Neighbours: /usr/users/werthm/AcquRoot/acqu/acqu/data/Dec_07/TAPS/BaF2.dat
+#Veto.Correlation.Neighbours: /usr/users/werthm/AcquRoot/acqu/acqu/data/Feb_09/TAPS/BaF2_PWO.dat
+#Veto.Correlation.Neighbours: /usr/users/werthm/AcquRoot/acqu/acqu/data/May_09/TAPS/BaF2_PWO.dat
+Veto.Correlation.Histo.Fit.Name: CaLib_Veto_Corr
+
+# Energy calibration
+Veto.Energy.MC.File: $CALIB/data/MC_Veto.root
+Veto.Energy.Histo.MC.Name: proton
+Veto.Energy.Histo.Fit.Name: CaLib_Veto_dE_E
+Veto.Energy.Histo.Fit.Xaxis.Range: 0 800
+Veto.Energy.Fit.Range: 50 60
+Veto.Energy.Histo.Overview.Yaxis.Range: 0 10
+
+# Time calibration
+Veto.Time.Histo.Fit.Name:  CaLib_Veto_Time
+Veto.Time.Histo.Fit.Xaxis.Range: -10 10
+Veto.Time.Histo.Overview.Yaxis.Range: -5 5
+
+# LED calibration
+#Veto.LED.ADCList: /usr/users/werthm/AcquRoot/acqu/acqu/data/Dec_07/TAPS/Veto.dat
+#Veto.LED.ADCList: /usr/users/werthm/AcquRoot/acqu/acqu/data/Feb_09/TAPS/Veto.dat
+Veto.LED.ADCList: /usr/users/werthm/AcquRoot/acqu/acqu/data/May_09/TAPS/Veto.dat
+Veto.LED.E0.Set: 0
+Veto.LED.E1.Set: 0
+Veto.LED.Histo.Fit.Xaxis.Range: 80 180
+Veto.LED.Histo.Overview.Yaxis.Range: 0 2
+

--- a/CaLib/include/TCFileManager.h
+++ b/CaLib/include/TCFileManager.h
@@ -13,8 +13,12 @@
 //////////////////////////////////////////////////////////////////////////
 
 
-#ifndef TCFILEMANAGER_H 
+#ifndef TCFILEMANAGER_H
 #define TCFILEMANAGER_H
+
+#include <dirent.h>
+#include <string.h>
+#include <list>
 
 #include "TFile.h"
 #include "TH1.h"
@@ -33,13 +37,17 @@ private:
     TString fCalibration;                   // calibration identifier
     Int_t fNset;                            // number of sets
     Int_t* fSet;                            //[fNset] array of set numbers
-    
+
     void BuildFileList();
+    // used to read in MC files
+    const char* join_path(const char* path1, const char* path2, const char* path_sep);
+    void list_files(const char* path, std::list<std::string>& file_list);
+    void filter_list(std::list<std::string>& list, const char* pattern);
 
 public:
-    TCFileManager() : fInputFilePatt(0), fFiles(0), 
+    TCFileManager() : fInputFilePatt(0), fFiles(0),
                       fCalibData(), fCalibration(), fNset(0), fSet(0) { }
-    TCFileManager(const Char_t* data, const Char_t* calibration, 
+    TCFileManager(const Char_t* data, const Char_t* calibration,
                   Int_t nSet, Int_t* set, const Char_t* filePat = 0);
     virtual ~TCFileManager();
 

--- a/CaLib/include/TCFileManager.h
+++ b/CaLib/include/TCFileManager.h
@@ -18,7 +18,9 @@
 
 #include <dirent.h>
 #include <string.h>
+#include <limits.h>
 #include <list>
+#include <libgen.h>  // basename(), dirname()
 
 #include "TFile.h"
 #include "TH1.h"
@@ -43,6 +45,7 @@ private:
     const char* join_path(const char* path1, const char* path2, const char* path_sep);
     void list_files(const char* path, std::list<std::string>& file_list);
     void filter_list(std::list<std::string>& list, const char* pattern);
+    const char* get_real_path(const char* path);
 
 public:
     TCFileManager() : fInputFilePatt(0), fFiles(0),

--- a/CaLib/include/TCMySQLManager.h
+++ b/CaLib/include/TCMySQLManager.h
@@ -44,6 +44,7 @@ private:
     THashList* fData;                           // calibration data
     THashList* fTypes;                          // calibration types
     static TCMySQLManager* fgMySQLManager;      // pointer to static instance of this class
+    bool MC;
     
     Bool_t ReadCaLibData();
     Bool_t ReadCaLibTypes();
@@ -153,6 +154,11 @@ public:
                 const Char_t* newCalibName = 0);
     Bool_t RemoveDataSet(const Char_t* data, const Char_t* calibration, Int_t set);
 
+    void SetMC(bool _mc = true)
+    {
+        MC = _mc;
+    }
+
     static TCMySQLManager* GetManager()
     {
         // return a pointer to the static instance of this class
@@ -162,7 +168,8 @@ public:
             Error("GetManager", "No connection to the database!");
             return 0;
         }
-        else return fgMySQLManager;
+        else
+            return fgMySQLManager;
     }
     
     ClassDef(TCMySQLManager, 0) // Communication with MySQL Server

--- a/CaLib/include/TCMySQLManager.h
+++ b/CaLib/include/TCMySQLManager.h
@@ -137,7 +137,7 @@ public:
     
     TCContainer* LoadContainer(const Char_t* filename);
     
-    Int_t DumpRuns(TCContainer* container, Int_t first_run = 0, Int_t last_run = 0);
+    Int_t DumpRuns(TCContainer* container, Int_t first_run = -1, Int_t last_run = -1);
     Int_t DumpAllCalibrations(TCContainer* container, const Char_t* calibration);
     Int_t DumpCalibrations(TCContainer* container, const Char_t* calibration, 
                            const Char_t* data);

--- a/CaLib/macros/AddBeamtime.C
+++ b/CaLib/macros/AddBeamtime.C
@@ -24,8 +24,8 @@ void AddBeamtime()
     // the other parts of the code unchanged
     const Int_t firstRun            = 4921;
     const Int_t lastRun             = 6008;
-    const Char_t calibName[]        = "2014-07_EPT_Prod_Neiser";
-    const Char_t calibDesc[]        = "Calibration for July 2014 EPT Beamtime";
+    const Char_t calibName[]        = "2015-MC-Init-Test";
+    const Char_t calibDesc[]        = "Calibration for MC data, test to set proper starting values";
     const Char_t calibFileTagger[]  = "../acqu_user/data/Detector-EPT.dat";
     const Char_t calibFileCB[]      = "../acqu_user/data/Detector-NaI.dat";
     const Char_t calibFileTAPS[]    = "../acqu_user/data/Detector-BaF2-PbWO4.dat";
@@ -38,6 +38,9 @@ void AddBeamtime()
     //const Char_t target[]           = "LD2";    
     //TCMySQLManager::GetManager()->AddRunFiles(rawfilePath, target);
     
+    // set MC mode to pass 0s and 1s to the database for gains, offset, pedestals, etc.
+    TCMySQLManager::GetManager()->SetMC(true);
+
     // read AcquRoot calibration of tagger
     TCMySQLManager::GetManager()->AddCalibAR(kDETECTOR_TAGG, calibFileTagger,
                                              calibName, calibDesc,

--- a/CaLib/macros/AddCalibMC.C
+++ b/CaLib/macros/AddCalibMC.C
@@ -18,19 +18,22 @@
 void AddCalibMC()
 {
     // load CaLib
-    gSystem->Load("libCaLib.so");
+    gSystem->Load("../build/lib/libCaLib.so");
  
     // macro configuration: just change here for your beamtime and leave
     // the other parts of the code unchanged
-    const Char_t target[]           = "LD2";
+    const Char_t target[]           = "LH2";
     const Int_t dummyRun            = 999001;
-    const Char_t calibName[]        = "LD2_MC_Feb_09";
-    const Char_t calibDesc[]        = "MC calibration for February 2009 beamtime";
-    const Char_t calibFileTagger[]  = "/usr/users/werthm/AcquRoot/acqu/acqu/data/MC_Feb_09/LadderMC.dat";
-    const Char_t calibFileCB[]      = "/usr/users/werthm/AcquRoot/acqu/acqu/data/MC_Feb_09/NaI_MC.dat";
-    const Char_t calibFileTAPS[]    = "/usr/users/werthm/AcquRoot/acqu/acqu/data/MC_Feb_09/BaF2_MC_09.dat";
-    const Char_t calibFilePID[]     = "/usr/users/werthm/AcquRoot/acqu/acqu/data/MC_Feb_09/PID2_MC.dat";
-    const Char_t calibFileVeto[]    = "/usr/users/werthm/AcquRoot/acqu/acqu/data/MC_Feb_09/Veto_MC.dat";
+    const Char_t calibName[]        = "2015-MC-Init-Test";
+    const Char_t calibDesc[]        = "Calibration for MC data, test to set proper starting values";
+    const Char_t calibFileTagger[]  = "../acqu_user/data/AR-Analysis-Tagger-EPT.dat";
+    const Char_t calibFileCB[]      = "../acqu_user/data/AR-Analysis-CB-NaI.dat";
+    const Char_t calibFileTAPS[]    = "../acqu_user/data/AR-Analysis-TAPS-BaF2.dat";
+    const Char_t calibFilePID[]     = "../acqu_user/data/AR-Analysis-CB-PID.dat";
+    const Char_t calibFileVeto[]    = "../acqu_user/data/AR-Analysis-TAPS-Veto.dat";
+
+    // set MC mode to pass 0s and 1s to the database for gains, offset, pedestals, etc.
+    TCMySQLManager::GetManager()->SetMC(true);
 
     // add raw files to the database
     TCMySQLManager::GetManager()->AddRun(dummyRun, target, calibDesc);

--- a/CaLib/src/MainCaLibManager.cxx
+++ b/CaLib/src/MainCaLibManager.cxx
@@ -1075,8 +1075,8 @@ void ExportRuns()
 {
     // Export runs.
     
-    Int_t first_run = 0;
-    Int_t last_run = 0;
+    Int_t first_run = -1;
+    Int_t last_run = -1;
     Char_t filename[256];
     Char_t answer[16];
 
@@ -1095,15 +1095,15 @@ void ExportRuns()
     attroff(A_UNDERLINE);
   
     // ask first run, last run and file name
-    mvprintw(6, 2, "First run (enter 0 to select all)          : ");
+    mvprintw(6, 2, "First run (enter -1 to select all)          : ");
     scanw((Char_t*)"%d", &first_run);
-    mvprintw(7, 2, "Last run  (enter 0 to select all)          : ");
+    mvprintw(7, 2, "Last run  (enter -1 to select all)          : ");
     scanw((Char_t*)"%d", &last_run);
     mvprintw(8, 2, "Name of output file                        : ");
     scanw((Char_t*)"%s", filename);
 
     // ask confirmation
-    if (!first_run && !last_run)
+    if (first_run == -1 && last_run == -1)
         mvprintw(10, 2, "Saving all runs to '%s'", filename);
     else
         mvprintw(10, 2, "Saving runs %d to %d to '%s'", first_run, last_run, filename);

--- a/CaLib/src/TCFileManager.cxx
+++ b/CaLib/src/TCFileManager.cxx
@@ -25,7 +25,7 @@ TCFileManager::TCFileManager(const Char_t* data, const Char_t* calibration,
     // 'calibration' and the 'nSet' sets in the array 'set'.
     // If filePat is non-zero use this file pattern instead of the one written
     // in the configuration file.
-    
+
     // init members
     fCalibData = data;
     fCalibration = calibration;
@@ -42,7 +42,7 @@ TCFileManager::TCFileManager(const Char_t* data, const Char_t* calibration,
         if (TString* f = TCReadConfig::GetReader()->GetConfig("File.Input.Rootfiles"))
         {
             fInputFilePatt = *f;
-            
+
             // check file pattern
             if (!fInputFilePatt.Contains("RUN"))
             {
@@ -74,38 +74,47 @@ TCFileManager::~TCFileManager()
 void TCFileManager::BuildFileList()
 {
     // Build the list of files belonging to the runsets.
-    
-    // loop over sets
-    for (Int_t i = 0; i < fNset; i++)
+
+    // check if MC files should be read
+    if (TCReadConfig::GetReader()->GetConfigInt("File.Input.MC"))
     {
-        // get the list of runs for this set
-        Int_t nRun;
-        Int_t* runs = TCMySQLManager::GetManager()->GetRunsOfSet(fCalibData.Data(), fCalibration.Data(), fSet[i], &nRun);
+        const char* path = TCReadConfig::GetReader()->GetConfig("File.MC.Directory")->Data();
+        const int run_number = TCReadConfig::GetReader()->GetConfigInt("File.MC.RunNumber");
+        const char ext[8] = ".root";
+        std::list<std::string> files;
+
+        list_files(path, files);
+        if (files.empty()) {
+            fprintf(stderr, "Directory '%s' doesn't contain any files!\n", path);
+            exit(EXIT_FAILURE);
+        }
+
+        // filter the list for root files
+        filter_list(files, ext);
+        if (files.empty()) {
+            fprintf(stderr, "Directory '%s' doesn't contain any %s-files!\n", ext, path);
+            exit(EXIT_FAILURE);
+        }
+
+        for (std::list<std::string>::iterator it = files.begin(); it != files.end(); ++it)
+            printf("%s\n", *it);
+
+        exit(EXIT_SUCCESS);
 
         // user information
-        Info("BuildFileList", "Adding runs of set %d", fSet[i]);
+        Info("BuildFileList", "Adding MC files");
 
-        // loop over runs
-        for (Int_t j = 0; j < nRun; j++)
+        // loop over all collected MC files
+        unsigned int i = 0;  // file counter for terminal output
+        for (std::list<std::string>::iterator it = files.begin(); it != files.end(); ++it)
         {
-            // construct file name
-            TString filename(fInputFilePatt);
-            filename.ReplaceAll("RUN", TString::Format("%d", runs[j]));
-            
             // open the file
-            TFile* f = TFile::Open(filename.Data());
-            
-            // check nonexisting file
-            if (!f) 
-            {   
-                Warning("BuildFileList", "Could not open file '%s'", filename.Data());
-                continue;
-            }
+            TFile* f = TFile::Open((*it).c_str());
 
-            // check bad file
-            if (f->IsZombie())
+            // check for nonexisting or bad file
+            if (!f || f->IsZombie())
             {
-                Warning("BuildFileList", "Could not open file '%s'", filename.Data());
+                Warning("BuildFileList", "Could not open file '%s'", *it);
                 continue;
             }
 
@@ -113,11 +122,54 @@ void TCFileManager::BuildFileList()
             fFiles->Add(f);
 
             // user information
-            Info("BuildFileList", "%03d : added file '%s'", j, f->GetName());
+            Info("BuildFileList", "%03d : added file '%s'", ++i, f->GetName());
         }
+    }
+    else  // else loop over run sets
+    {
+        for (Int_t i = 0; i < fNset; i++)
+        {
+            // get the list of runs for this set
+            Int_t nRun;
+            Int_t* runs = TCMySQLManager::GetManager()->GetRunsOfSet(fCalibData.Data(), fCalibration.Data(), fSet[i], &nRun);
 
-        // clean-up
-        delete runs;
+            // user information
+            Info("BuildFileList", "Adding runs of set %d", fSet[i]);
+
+            // loop over runs
+            for (Int_t j = 0; j < nRun; j++)
+            {
+                // construct file name
+                TString filename(fInputFilePatt);
+                filename.ReplaceAll("RUN", TString::Format("%d", runs[j]));
+
+                // open the file
+                TFile* f = TFile::Open(filename.Data());
+
+                // check nonexisting file
+                if (!f)
+                {
+                    Warning("BuildFileList", "Could not open file '%s'", filename.Data());
+                    continue;
+                }
+
+                // check bad file
+                if (f->IsZombie())
+                {
+                    Warning("BuildFileList", "Could not open file '%s'", filename.Data());
+                    continue;
+                }
+
+                // add good file to list
+                fFiles->Add(f);
+
+                // user information
+                Info("BuildFileList", "%03d : added file '%s'", j, f->GetName());
+            }
+
+            // clean-up
+            delete runs;
+        }
     }
 }
 
@@ -135,7 +187,7 @@ TH1* TCFileManager::GetHistogram(const Char_t* name)
         Error("GetHistogram", "ROOT file list is empty!");
         return 0;
     }
-    
+
     // do not keep histograms in memory
     TH1::AddDirectory(kFALSE);
 
@@ -152,15 +204,15 @@ TH1* TCFileManager::GetHistogram(const Char_t* name)
         if (h)
         {
             // correct destroying
-            h->ResetBit(kMustCleanup);  
+            h->ResetBit(kMustCleanup);
 
             // check if object is really a histogram
             if (h->InheritsFrom("TH1"))
             {
                 // check if it is the first one
-                if (first) 
+                if (first)
                 {
-                    hOut = (TH1*) h->Clone();      
+                    hOut = (TH1*) h->Clone();
                     first = kFALSE;
                 }
                 else hOut->Add(h);
@@ -183,4 +235,61 @@ TH1* TCFileManager::GetHistogram(const Char_t* name)
 
     return hOut;
 }
+
+//______________________________________________________________________________
+
+/**
+ * The following methods are used to recursively read in root files
+ * for a given directory in the case of MC files
+ */
+
+// join to path segements to a full path
+const char* TCFileManager::join_path(const char* path1,
+                                     const char* path2,
+                                     const char* path_sep = "/")
+{
+	char* path = new char[128];
+	strcpy(path, path1);
+	strcat(path, path_sep);
+	strcat(path, path2);
+
+	return path;
+}
+
+// recursively get all files from a given directory path
+void TCFileManager::list_files(const char* path, std::list<std::string>& file_list)
+{
+	DIR *dir;
+	struct dirent *ent;
+
+	if (dir = opendir(path)) {
+		while (ent = readdir(dir))  // loop over dir as long as ent gets a pointer assigned
+			if (ent->d_type == DT_DIR)  // is directory?
+				if (!strcmp(ent->d_name, ".") || !strcmp(ent->d_name, ".."))
+					continue;  // skip . and .. dirs
+				else
+					list_files(join_path(path, ent->d_name), file_list);
+			else
+				file_list.push_back(join_path(path, ent->d_name));
+
+		closedir(dir);
+	} else {
+		fprintf(stderr, "The directory '%s' could not be read!\n", std::string(ent->d_name));
+		exit(EXIT_FAILURE);
+	}
+
+	return;
+}
+
+// remove all entries from the list which don't contain the given pattern
+void TCFileManager::filter_list(std::list<std::string>& list, const char* pattern)
+{
+	std::list<std::string>::iterator it = list.begin();
+	while (it != list.end())
+		if (!strstr((*it).c_str(), pattern))
+			it = list.erase(it);
+		else
+			it++;
+}
+
 ClassImp(TCFileManager)

--- a/CaLib/src/TCMySQLManager.cxx
+++ b/CaLib/src/TCMySQLManager.cxx
@@ -26,6 +26,7 @@ TCMySQLManager::TCMySQLManager()
 {
     // Constructor.
 
+    MC = false;
     fDB = 0;
     fSilence = kFALSE;
     fData = new THashList();
@@ -1301,10 +1302,17 @@ void TCMySQLManager::AddCalibAR(CalibDetector_t det, const Char_t* calibFileAR,
     for (Int_t i = 0; i < nDet; i++)
     {
         eL[i] = r.GetElement(i)->GetEnergyLow();
-        e0[i] = r.GetElement(i)->GetPedestal();
-        e1[i] = r.GetElement(i)->GetADCGain();
-        t0[i] = r.GetElement(i)->GetOffset();
-        t1[i] = r.GetElement(i)->GetTDCGain();
+        if (!MC) {
+            e0[i] = r.GetElement(i)->GetPedestal();
+            e1[i] = r.GetElement(i)->GetADCGain();
+            t0[i] = r.GetElement(i)->GetOffset();
+            t1[i] = r.GetElement(i)->GetTDCGain();
+        } else {
+            e0[i] = 0.;
+            e1[i] = 1.;
+            t0[i] = 0.;
+            t1[i] = 1.;
+        }
     }
 
     // read detector specific calibration values
@@ -1352,8 +1360,13 @@ void TCMySQLManager::AddCalibAR(CalibDetector_t det, const Char_t* calibFileAR,
             // read SG parameters
             for (Int_t i = 0; i < nDetSG; i++)
             {
-                e0SG[i] = rSG.GetElement(i)->GetPedestal();
-                e1SG[i] = rSG.GetElement(i)->GetADCGain();
+                if (!MC) {
+                    e0SG[i] = rSG.GetElement(i)->GetPedestal();
+                    e1SG[i] = rSG.GetElement(i)->GetADCGain();
+                } else {
+                    e0SG[i] = 0.;
+                    e1SG[i] = 1.;
+                }
             }
 
             // write to database

--- a/acqu_core/AcquRoot/src/ARFile_t.cc
+++ b/acqu_core/AcquRoot/src/ARFile_t.cc
@@ -170,11 +170,9 @@ Int_t ARFile_t::ReadKey( const Map_t** keylist )
     for( j=0; ; j++ ){
       list = keylist[j];
       if( !list ){
-        printf("WARNING: Key '%s' in file %s not found!\n", keyword, fName);
-        // return -2 instead of -1 to prevent skipping the rest of the
-        // config file if the key is not specified in any config-key map;
-        // this will only result in an error entry in the Analysis.log
-        return -2;
+        printf("ERROR: Key '%s' in file %s not found!\n", keyword, fName);
+        printf("  I'm exiting now...\n");
+        exit(1);
       }
       for( i=0; ; i++){
 	k = list[i].fFnName;

--- a/acqu_core/AcquRoot/src/HitD2A_t.cc
+++ b/acqu_core/AcquRoot/src/HitD2A_t.cc
@@ -63,6 +63,12 @@ HitD2A_t::HitD2A_t(char* line, UInt_t nelem, TA2Detector* det , Bool_t ignorePos
 		    tdcstr, &fTimeLowThr, &fTimeHighThr, &fT0, &fT1,
 		    &xpos, &ypos, &zpos );
 
+  // in case we have MC data, set fA1 to 1 and fT0 to 0
+  if (gAR->GetProcessType() == EMCProcess) {
+    fA1 = 1.;
+    fT0 = 0.;
+  }
+
   if( i < 10 ){
     // Error in input line...ignore it
     printf(" Error ignore create HitD2A from input line:\n %s\n",line);

--- a/acqu_user/root/src/TA2AccessSQL.cc
+++ b/acqu_user/root/src/TA2AccessSQL.cc
@@ -60,12 +60,7 @@ void TA2AccessSQL::SetConfig(Char_t* line, Int_t key)
   switch (key)
   {
   case ESQL_USE_CALIB:
-  {   
-    if(fIsMC) {
-      Error("SetConfig", "Ignoring Calib statements due to MC run");
-      return;
-    }
-      
+  {
     Char_t tmp[5][256];
     
     // read CaLib parameters
@@ -220,6 +215,13 @@ void TA2AccessSQL::SetConfig(Char_t* line, Int_t key)
       }
     }
     else Error("SetConfig", "CaLib Veto calibration could not be configured!");
+    break;
+  }
+  case ESQL_CALIB_MCRUNNR:
+  {
+    // read run number for MC files
+    if (sscanf(line, "%d", &fRunNumber) != 1)
+      Error("SetConfig", "CaLib MC run number could not be set!");
     break;
   }
   default:

--- a/acqu_user/root/src/TA2AccessSQL.h
+++ b/acqu_user/root/src/TA2AccessSQL.h
@@ -40,7 +40,8 @@ enum {
   ESQL_CALIB_CB,
   ESQL_CALIB_TAPS,
   ESQL_CALIB_PID,
-  ESQL_CALIB_VETO
+  ESQL_CALIB_VETO,
+  ESQL_CALIB_MCRUNNR
 };
 
 static const Map_t AccessSQLConfigKeys[] = {
@@ -51,6 +52,7 @@ static const Map_t AccessSQLConfigKeys[] = {
   {"Use-CaLib-TAPS:"               , ESQL_CALIB_TAPS},                     // key for CaLib TAPS configuration
   {"Use-CaLib-PID:"                , ESQL_CALIB_PID},                      // key for CaLib PID configuration
   {"Use-CaLib-Veto:"               , ESQL_CALIB_VETO},                     // key for CaLib Veto configuration
+  {"MC-Run-Number:"                , ESQL_CALIB_MCRUNNR},                  // key to determine run number for MC files
   // Termination
   {NULL        , -1           }
 };

--- a/acqu_user/root/src/TA2CalArray.cc
+++ b/acqu_user/root/src/TA2CalArray.cc
@@ -26,8 +26,7 @@
 enum
 {
   ECAEnergyResolution=1900, ECATimeResolution, ECAThetaResolution, ECAPhiResolution,
-  ECAClusterUCLA,
-  ECAScaleFile
+  ECAClusterUCLA
 };
 
 static const Map_t kCalArrayKeys[] =
@@ -39,7 +38,6 @@ static const Map_t kCalArrayKeys[] =
   {"Max-Cluster:",         EClustDetMaxCluster},
   {"Next-Neighbour:",      EClustDetNeighbour},
   {"Cluster-UCLA:",        ECAClusterUCLA},
-  {"Scale-File:",          ECAScaleFile},
   {NULL,            -1}
 };
 
@@ -65,11 +63,6 @@ TA2CalArray::TA2CalArray(const char* name, TA2System* apparatus)
   fSigmaTheta           = -1.0;
   fSigmaPhi             = -1.0;
   fEthresh              = 0.0;
-
-  ScaleRuns = 0;
-  ScaleVal[0] = 1.0;
-  UseScales = false;
-  CurrentRun[0] = '\0';
 
   fRandom = new TRandom();
 
@@ -104,30 +97,10 @@ TA2CalArray::~TA2CalArray()
 
 void TA2CalArray::SetConfig(char* line, int key)
 {
-  FILE* ScalFile;
-
   // Load CalArray parameters from file or command line
   // CalArray specific configuration
   switch(key)
   {
-  case ECAScaleFile:
-    if(sscanf(line, "%s", ScaleFile) < 1)
-    {
-      PrintError(line,"<TA2CalArray Scale File>");
-      break;
-    }
-    printf("NaI energy scale values from:\n %s\n", ScaleFile);
-    ScalFile = fopen(ScaleFile, "r");
-    ScaleRuns = 0;
-    while(!feof(ScalFile))
-      if(fscanf(ScalFile, "%s %lf", ScaleRun[ScaleRuns], &ScaleVal[ScaleRuns])==2)
-      {
-        ScaleRuns++;
-        if(ScaleRuns > MAXRUNS) break;
-      }
-    fclose(ScalFile);
-    UseScales = true;
-    break;
   case ECAClusterUCLA:
     // Set Clustering Algorithm to UCLA version
     fUseClusterDecodeUCLA = 1;
@@ -226,9 +199,6 @@ void TA2CalArray::PostInit()
   if(fUseClusterDecodeUCLA) printf("Using UCLA ClusterDecode for Crystal Ball NaI array\n");
 
   fEnergyAll = new Double_t[fNelem+1];
-
-  //Store global energy scale value
-  fEnergyGlobal = fEnergyScale;
 
   TA2ClusterDetector::PostInit();
 }

--- a/acqu_user/root/src/TA2CalArray.cc
+++ b/acqu_user/root/src/TA2CalArray.cc
@@ -26,7 +26,7 @@
 enum
 {
   ECAEnergyResolution=1900, ECATimeResolution, ECAThetaResolution, ECAPhiResolution,
-  ECAClusterUCLA
+  ECAClusterUCLA, ECAOffsetTime
 };
 
 static const Map_t kCalArrayKeys[] =
@@ -38,6 +38,7 @@ static const Map_t kCalArrayKeys[] =
   {"Max-Cluster:",         EClustDetMaxCluster},
   {"Next-Neighbour:",      EClustDetNeighbour},
   {"Cluster-UCLA:",        ECAClusterUCLA},
+  {"Offset-Time:",         ECAOffsetTime},
   {NULL,            -1}
 };
 
@@ -60,6 +61,7 @@ TA2CalArray::TA2CalArray(const char* name, TA2System* apparatus)
   fSigmaEnergyFactor    = -1.0;
   fSigmaEnergyPower     = -1.0;
   fSigmaTime            = -1.0;
+  fOffsetTime           = 0.0;
   fSigmaTheta           = -1.0;
   fSigmaPhi             = -1.0;
   fEthresh              = 0.0;
@@ -161,6 +163,11 @@ void TA2CalArray::SetConfig(char* line, int key)
   fNCluster++;
       }
     else TA2ClusterDetector::SetConfig(line, key);
+    break;
+  case ECAOffsetTime:
+    // Time offset read-in line
+    if(sscanf(line, "%lf", &fOffsetTime) < 1)
+      PrintError(line,"<TA2CalArray Time Offset>");
     break;
   default:
     // Command not found...possible pass to next config

--- a/acqu_user/root/src/TA2CalArray.h
+++ b/acqu_user/root/src/TA2CalArray.h
@@ -26,8 +26,6 @@
 #include "TA2UserControl.h"
 //#include <iostream>
 
-#define MAXRUNS 2047
-
 class TA2CalArray : public TA2ClusterDetector
 {
  private:
@@ -44,17 +42,6 @@ class TA2CalArray : public TA2ClusterDetector
   Double_t  fSigmaPhi;              // Phi Resolution for CB
   UInt_t*   fTryHits;               // Element-Hit store - Sergey
   UInt_t*   fTempHits2;             // Element-Hit store - Sergey
-
-  //For run-by-run energy scale factor handling:
-  Bool_t UseScales;
-  Int_t iRun;
-  Int_t ScaleRuns;
-  Char_t RunName[1024];
-  Char_t CurrentRun[1024];
-  Char_t ScaleFile[1024];
-  Char_t ScaleRun[MAXRUNS+1][256];
-  Double_t ScaleVal[MAXRUNS+1];
-  Double_t fEnergyGlobal;
 
  public:
   TA2CalArray(const char*, TA2System*);// Normal use
@@ -407,22 +394,6 @@ inline void TA2CalArray::Decode()
   // Decode raw TDC and Scaler information into
   // Hit pattern, "Energy" pattern, aligned OR etc.
 
-  if(UseScales)
-  {
-    //Get name of file being analysed
-    gUAN->ReadRunName(RunName);
-    //Check if file name has changed since last event (i.e. are we analysing a new file)
-    if(strcmp(RunName, CurrentRun))
-    {
-      strcpy(CurrentRun, RunName);
-      //Find current run in energy scale table
-      for(iRun=0; iRun<ScaleRuns; iRun++)
-        if(!strcmp(RunName, ScaleRun[iRun])) break;
-      //Apply additional run-dependent correction for global energy scale value
-      fEnergyScale = fEnergyGlobal*ScaleVal[iRun];
-    }
-  }
-
   if(fUseClusterDecodeUCLA)
   {
     TA2ClusterDetector::DecodeBasic();
@@ -455,22 +426,6 @@ inline void TA2CalArray::ReadDecoded()
   // See MCBranchID.h for GEANT-3 output details.
   // Add energy thresholds 25/10/05
   // D.Glazier addition of time decoding from A2 Geant4 model 24/08/07
-
-  if(UseScales)
-  {
-    //Get name of file being analysed
-    gUAN->ReadRunName(RunName);
-    //Check if file name has changed since last event (i.e. are we analysing a new file)
-    if(strcmp(RunName, CurrentRun))
-    {
-      strcpy(CurrentRun, RunName);
-      //Find current run in energy scale table
-      for(iRun=0; iRun<ScaleRuns; iRun++)
-        if(!strcmp(RunName, ScaleRun[iRun])) break;
-      //Apply additional run-dependent correction for global energy scale value
-      fEnergyScale = fEnergyGlobal*ScaleVal[iRun];
-    }
-  }
 
   Double_t T, E;
   Double_t Lo, Hi;

--- a/acqu_user/root/src/TA2CalArray.h
+++ b/acqu_user/root/src/TA2CalArray.h
@@ -464,7 +464,7 @@ inline void TA2CalArray::ReadDecoded()
     if (fIsTime)
     {
       t = time[i] - fElement[elem]->GetT0() - fOffsetTime;
-      if (fSigmaTime > 0) t += fRandom->Gaus(0.0, fSigmaTime);
+      if (fSigmaTime > 0 && fUseSigmaTime) t += fRandom->Gaus(0.0, fSigmaTime);
 
       // check time range
       if ((t < fElement[elem]->GetTimeLowThr()) ||

--- a/acqu_user/root/src/TA2TAPS_BaF2.cc
+++ b/acqu_user/root/src/TA2TAPS_BaF2.cc
@@ -25,7 +25,7 @@
 enum {
   ETAPSSGMaxDet=510, ETAPSSG, EClustDetMaxTAPSCluster, EClustDetTAPSNeighbour,
   ETAPSEnergyResolution, ETAPSTimeResolution, ETAPSThetaResolution, ETAPSPhiResolution,
-  ETAPSVetoEnergy, ETAPSVetoEfficiency, ETAPSVetoThreshold,
+  ETAPSVetoEnergy, ETAPSVetoEfficiency, ETAPSVetoThreshold, ETAPSOffsetTime
 };
 
 // Command-line key words which determine what to read in
@@ -41,6 +41,7 @@ static const Map_t kTAPSClustDetKeys[] = {
   {"Veto-Energy:",         ETAPSVetoEnergy},
   {"Veto-Efficiency:",     ETAPSVetoEfficiency},
   {"Veto-Threshold:",      ETAPSVetoThreshold},
+  {"Offset-Time:",         ETAPSOffsetTime},
   {NULL,          -1}
 };
 
@@ -57,6 +58,7 @@ TA2TAPS_BaF2::TA2TAPS_BaF2(const char* name, TA2System* apparatus)
   fEnergyResolutionFactor = -1.0;
   fEnergyResolutionConst  = -1.0;
   fTimeResolution         = -1.0;
+  fTimeOffset             = 0.0;
   fThetaResolution        = -1.0;
   fPhiResolution          = -1.0;
 
@@ -136,12 +138,12 @@ void TA2TAPS_BaF2::SetConfig(Char_t* line, Int_t key)
       PrintError(line,"<TA2TAPS_BaF2 Time Resolution>");
     break;
    case ETAPSThetaResolution:
-    // Time resolution read-in line
+    // Theta resolution read-in line
     if(sscanf(line, "%lf", &fThetaResolution) < 1)
       PrintError(line,"<TA2TAPS_BaF2 Theta Resolution>");
     break;
    case ETAPSPhiResolution:
-    // Time resolution read-in line
+    // Phi resolution read-in line
     if(sscanf(line, "%lf", &fPhiResolution) < 1)
       PrintError(line,"<TA2TAPS_BaF2 Phi Resolution>");
     break;
@@ -200,7 +202,12 @@ void TA2TAPS_BaF2::SetConfig(Char_t* line, Int_t key)
     if(fNCluster < fNelement) fCluster[fNCluster] = new HitClusterTAPS_t(line, fNCluster);
     fNCluster++;
     break;
-   default:
+  case ETAPSOffsetTime:
+    // Time offset read-in line
+    if(sscanf(line, "%lf", &fOffsetTime) < 1)
+      PrintError(line,"<TA2TAPS_BaF2 Timeoffset>");
+    break;
+  default:
     // Command not found...possible pass to next config
     TA2ClusterDetector::SetConfig(line, key);
     fIsConfigPass = ETrue;
@@ -263,170 +270,6 @@ void TA2TAPS_BaF2::PostInit()
 
   TA2ClusterDetector::PostInit();
   fLGEnergy = TA2Detector::GetElement();
-}
-
-//---------------------------------------------------------------------------
-
-inline void TA2TAPS_BaF2::ReadDecoded()
-{
-  // Read back "decoded" data for the BaF2 array
-  // In this case produced by the GEANT3 CB simulation
-
-  UInt_t j;
-  Int_t nVetos = 0;
-  Int_t nBaF2s = 0;
-  Double_t total = 0.0;
-  fNhits = *(Int_t*)(fEvent[EI_ntaps]);
-  Float_t* energy = (Float_t*)(fEvent[EI_ectapsl]);
-  Float_t* time = (Float_t*)(fEvent[EI_tctaps]);
-  UInt_t* index = (UInt_t*)(fEvent[EI_ictaps]);
-  Float_t* venergy = (Float_t*)(fEvent[EI_evtaps]);
-  Float_t* dircos = (Float_t*)(fEvent[EI_dircos]);
-  Int_t npart = *(Int_t*)(fEvent[EI_npart]);
-  Int_t* idpart = (Int_t*)(fEvent[EI_idpart]);
-  Double_t E, T;                                    //Energy, time
-  Double_t LoE, HiE, LoT, HiT;
-  Int_t proton;
-  Double_t dphi, dtheta;
-  Double_t domega2, temp2;
-  UInt_t crystal;
-  Double_t Efficiency = 0.0;
-  Double_t GammaToF;
-  Bool_t IsBaF2;
-
-  //Find proton index in simulated data
-  for(proton=0; proton<npart; proton++)
-    if(idpart[proton]==14) break; //14 = GEANT proton
-  //Move pointer to correct positions for proton data
-  for(Int_t t=0; t<proton; t++) //For all particles before proton:
-    for(Int_t i=0;i<3; i++) dircos++; //Jump over x,y,z components
-  //Read x,y,z components for proton
-  Double_t x_p = *dircos++;
-  Double_t y_p = *dircos++;
-  Double_t z_p = *dircos;
-  //Calculate theta and phi angles out of cartesian components
-  Double_t theta_p = acos(z_p);
-  Double_t phi_p = atan2(y_p, x_p);
-
-  //For each crystal: evaluate deviation from proton direction in theta-phi plane
-  domega2 = 1e38;
-  crystal = 65535;
-  if(theta_p < (TMath::DegToRad()*20.0))
-    for(UInt_t t=0; t<fNelem; t++)
-    {
-      dtheta = theta_p - theta_c[t];
-      dphi = phi_p - phi_c[t];
-      if(dphi > TMath::Pi()) dphi = TMath::TwoPi() - dphi;
-      if(dphi < -TMath::Pi()) dphi = -TMath::TwoPi() - dphi;
-       //Find crystal which fits best for proton direction in theta-phi plane
-      temp2 = dphi*dphi + dtheta*dtheta;
-      if(temp2 < domega2)
-      {
-        domega2 = temp2;
-        crystal = t;
-      }
-    }
-
-  //I want this empty...
-  if(fMaxSGElements)
-    for(UInt_t t=0; t<fMaxSGElements; t++)
-      fSGEnergyValue[t] = EBufferEnd;
-  for(UInt_t t=0; t<fNelem; t++)
-  {
-    if(fPatternHits) fPatternHits[0][t] = EBufferEnd;
-    EnergyAll[t] = 0.0;
-  }
-
-  //Evaluate all simulated hits
-  for(UInt_t i=0; i<fNhits; i++)
-  {
-    j = index[i];
-    if(!j) break;
-    //Use following line for cbsim since 2006-06-22!
-    j--; //For reasons Stefan won't tell...
-    E = energy[i] * fEnergyScale;                                   //G3/4 output in GeV
-//    if(fUseEnergyResolution) E+=pRandoms->Gaus(0.0, GetEnergyResolutionGeV(E));
-    if(fUseEnergyResolution) E+=pRandoms->Gaus(0.0, GetSigmaEnergyGeV(E));
-    E*=1000.0;                                                      //G3/4 output in MeV
-    EnergyAll[j] = E;
-    GammaToF = (Z_c[j] * TMath::Cos(theta_c[j]))/30.0;
-    T = -time[i] + GammaToF + pRandoms->Gaus(0.0, fTimeResolution);
-
-   //Fill veto stuff...
-    if(fPatternHits) //...but only if bit pattern unit is active
-      if((venergy[i] * 1000.0) > fVetoThreshold) //If energy deposited: Veto Hit
-      {
-        if(E < fVetoEnergy[0]) Efficiency = fVetoEfficiency[0];
-        else if((E > fVetoEnergy[0]) && (E < fVetoEnergy[1])) Efficiency = fVetoEfficiency[1];
-        else if((E > fVetoEnergy[1]) && (E < fVetoEnergy[2])) Efficiency = fVetoEfficiency[2];
-        else if((E > fVetoEnergy[2]) && (E < fVetoEnergy[3])) Efficiency = fVetoEfficiency[3];
-        else if(E > fVetoEnergy[3]) Efficiency = fVetoEfficiency[4];
-        if(pRandoms->Rndm() < Efficiency)
-        {
-          fPatternHits[0][nVetos] = j;
-         nVetos++;
-        }
-      }
-
-    //Fill BaF2 stuff
-    LoE = fElement[j]->GetEnergyLowThr();
-    HiE = fElement[j]->GetEnergyHighThr();
-    LoT = fElement[j]->GetTimeLowThr();
-    HiT = fElement[j]->GetTimeHighThr();
-    if((E > LoE) && (E < HiE) && (T > LoT) && (T < HiT))
-    {
-      fEnergy[j] = E;
-      fTime[j] = T;
-      fEnergyOR[nBaF2s] = E;
-      fTimeOR[nBaF2s] = T;
-      fHits[nBaF2s] = j;
-      total+=E;
-      nBaF2s++;
-
-      //PSA - reasonable?
-      if(fMaxSGElements)
-      {
-        IsBaF2 = true;
-        if((fNelem==402) && ((j % 67) <  4)) IsBaF2 = false; //If 1 PbWO ring is installed, the first 4 crystals in a TAPS block are PbWO4s
-        if((fNelem==438) && ((j % 73) < 12)) IsBaF2 = false; //If 2 PbWO rings are installed, the first 12 crystals in a TAPS block are PbWO4s
-
-        if(IsBaF2) //Do PSA information only for BaF2s
-        {
-          if((j==crystal) || fCluster[j]->IsNeighbour(crystal)) //Hit in or near crystal best fitting for proton
-            //fSGEnergyValue[j] = E * TMath::Power(E, 0.05) * 0.65; //Sven's function
-            fSGEnergyValue[j] = -0.9691614 + 0.7108238*E + 0.1819194e-2*E*E - 0.9019634e-5*E*E*E + 0.1610750e-7*E*E*E*E; //Marc's function
-          else
-            fSGEnergyValue[j] = 0.96 * E;
-          fSGEnergyValue[j]+=pRandoms->Gaus(0.0, 0.25 * TMath::Sqrt(fSGEnergyValue[j]));
-        }
-        else
-         fSGEnergyValue[j] = E;
-      }
-    }
-  }
-
-  fHits[nBaF2s] = EBufferEnd;
-  fTimeOR[nBaF2s] = EBufferEnd;
-  fEnergyOR[nBaF2s] = EBufferEnd;
-  fNhits = nBaF2s;
-  fTotalEnergy = total;
-
-  if(fPatternHits)
-  {
-    fPatternHits[0][nVetos] = EBufferEnd;
-    fNPatternHits[0] = nVetos;
-    //Note, that this may conflict with other ReadDecoded() functions later on, as this destroys the venergy[]
-    //information! So, the bit pattern veto should not be used if another veto implementation is running!
-    for(UInt_t i=0; i<fNelem; i++) venergy[i] = 0.0; //Need to cleanup, so that no data from previous event remains
-  }
-
-  if(fIsRawHits)
-  {
-    fRawEnergyHits[0] = EBufferEnd;
-    fRawTimeHits[0] = EBufferEnd;
-  }
-
-  bSimul = true;
 }
 
 //-----------------------------------------------------------------------------

--- a/acqu_user/root/src/TA2TAPS_BaF2.h
+++ b/acqu_user/root/src/TA2TAPS_BaF2.h
@@ -55,6 +55,7 @@ class TA2TAPS_BaF2 : public TA2ClusterDetector
   Double_t  fEnergyResolutionFactor;   // Factor in Energy Resolution Equation
   Double_t  fEnergyResolutionConst;    // Power in energy Resolution Equation
   Double_t  fTimeResolution;           // Sigma for time resolution
+  Double_t  fOffsetTime;               // MC time offset
   Double_t  fThetaResolution;          // Theta resolution
   Double_t  fPhiResolution;            // Phi Resolution
   Double_t  fVetoThreshold;
@@ -85,7 +86,7 @@ class TA2TAPS_BaF2 : public TA2ClusterDetector
   HitD2A_t* GetLGElement(Int_t i);
   HitD2A_t* GetSGElement(Int_t i);
 
-    TAPSType_t GetType() const { return fType; }
+  TAPSType_t GetType() const { return fType; }
     
   ClassDef(TA2TAPS_BaF2,1)
 };
@@ -184,13 +185,16 @@ inline HitD2A_t* TA2TAPS_BaF2::GetSGElement(Int_t i)
 
 //---------------------------------------------------------------------------
 
+// resolution behaviour as given in PhysRev C 79, 035204 (2009)
 inline Double_t TA2TAPS_BaF2::GetEnergyResolutionGeV(Double_t pEnergy)
 {
   // Returns energy resolution in GeV when supplied Energy in GeV
   return (fEnergyResolutionFactor * TMath::Sqrt(pEnergy) + fEnergyResolutionConst * pEnergy);
-
 }
+
 //---------------------------------------------------------------------------
+
+// this function is assumed by default by the parameters in the config file
 inline Double_t TA2TAPS_BaF2::GetSigmaEnergyGeV(Double_t pEnergy)
 {
   // Returns energy resolution in GeV when supplied Energy in GeV
@@ -248,6 +252,186 @@ inline Double_t TA2TAPS_BaF2::GetTimeResolution()
 {
   // Returns time resolution in ns
   return fTimeResolution;
+}
+
+//---------------------------------------------------------------------------
+
+inline void TA2TAPS_BaF2::ReadDecoded()
+{
+  // Read back "decoded" data for the BaF2 array
+  // In this case produced by the GEANT simulation
+
+  Int_t nVetos = 0;
+  Int_t nBaF2s = 0;
+  Double_t total = 0.0;
+  fNhits = *(Int_t*)(fEvent[EI_ntaps]);
+  Float_t* energy = (Float_t*)(fEvent[EI_ectapsl]);
+  Float_t* time = (Float_t*)(fEvent[EI_tctaps]);
+  UInt_t* index = (UInt_t*)(fEvent[EI_ictaps]);
+  Float_t* venergy = (Float_t*)(fEvent[EI_evtaps]);
+  Float_t* dircos = (Float_t*)(fEvent[EI_dircos]);
+  Int_t npart = *(Int_t*)(fEvent[EI_npart]);
+  Int_t* idpart = (Int_t*)(fEvent[EI_idpart]);
+  Double_t E, T;  // Energy, time
+  UInt_t proton_crystal;
+
+  // Find proton index in simulated data
+  UInt_t proton = 0;
+  while (proton++ < (UInt_t)npart)
+    if (idpart[proton] == 14) break;  // 14 = GEANT proton
+
+  // Move pointer to correct positions of proton data
+  // Therefore skip all x, y, z components for all particles before the proton
+  for (UInt_t t = 0; t < proton; t++)
+    for (UInt_t i = 0; i < 3; i++) dircos++;
+  // Read x, y, and z components of proton
+  Double_t x_p = *dircos++;
+  Double_t y_p = *dircos++;
+  Double_t z_p = *dircos;
+  // Calculate proton theta and phi angles out of Cartesian components
+  Double_t theta_p = acos(z_p);
+  Double_t phi_p = atan2(y_p, x_p);
+
+  // For each crystal: evaluate deviation from proton direction in theta-phi plane
+  Double_t delta = 1e38;  // difference between the true proton position and the cluster hit
+  proton_crystal = 65535;  // id of the crystal closest to the true proton position
+  Double_t dphi, dtheta, tmp;
+
+  if (theta_p < (TMath::DegToRad()*22.0))  // check if proton hit is not off
+    for (UInt_t t = 0; t < fNelem; t++)
+    {
+      dtheta = theta_p - theta_c[t];
+      dphi = phi_p - phi_c[t];
+      if (dphi > TMath::Pi()) dphi = TMath::TwoPi() - dphi;
+      if (dphi < -TMath::Pi()) dphi = -TMath::TwoPi() - dphi;
+      tmp = dphi*dphi + dtheta*dtheta;
+      // Find crystal which fits best for proton direction in theta-phi plane
+      if (tmp < delta)
+      {
+        delta = tmp;
+        proton_crystal = t;
+      }
+    }
+
+  // Clear arrays / set them to EBufferEnd
+  if (fMaxSGElements)
+    memset(fSGEnergyValue, EBufferEnd, fMaxSGElements*sizeof(Double_t));
+  if (fPatternHits)
+    memset(fPatternHits[0], EBufferEnd, fNelem*sizeof(Int_t));
+  memset(EnergyAll, 0., fNelem*sizeof(Double_t));
+
+  // Finally evaluate all simulated hits
+  for (UInt_t i = 0; i < fNhits; i++)
+  {
+    if (!index[i]) break;
+    // IDs in simulation: 1 to n, here 0 to n-1
+    UInt_t elem = index[i] - 1;
+
+    // check for ignored element
+    if (fElement[elem]->IsIgnored()) continue;
+
+    // convert energy and smear
+    E = energy[i] * fEnergyScale * fElement[elem]->GetA1();
+    if (fUseEnergyResolution) E += pRandoms->Gaus(0.0, GetSigmaEnergyGeV(E));
+    E *= 1000.;
+    EnergyAll[elem] = E;
+
+    // check energy thresholds
+    if ((E < fElement[elem]->GetEnergyLowThr()) ||
+        (E > fElement[elem]->GetEnergyHighThr())) continue;
+
+    // convert time
+    T = 0.;
+    if (fIsTime)
+    {
+      T = time[i] - fElement[elem]->GetT0() - fOffsetTime;
+      if (fTimeResolution > 0) T += pRandoms->Gaus(0.0, fTimeResolution);
+
+      // check time thresholds
+      if ((T < fElement[elem]->GetTimeLowThr()) ||
+          (T > fElement[elem]->GetTimeHighThr())) continue;
+
+      // calculate time of flight
+      //TODO: What's with protons? Handle them differently! (Patrik A. and Sascha W.; 2015-06-17)
+      Double_t c = 30.; // speed of light, cm per ns
+      T += (Z_c[elem] * TMath::Cos(theta_c[elem]))/c;  // apply gamma TOF factor to time
+    }
+
+    /* at this point we have a valid hit */
+
+    // Fill Veto information
+    if(fPatternHits) // ... but only if bit pattern unit is active
+      if((venergy[i] * 1000.0) > fVetoThreshold) // Veto hit if deposited enery is above threshold
+      {
+        Double_t Efficiency = 0.;
+        if (E < fVetoEnergy[0]) Efficiency = fVetoEfficiency[0];
+        else if ((E > fVetoEnergy[0]) && (E < fVetoEnergy[1])) Efficiency = fVetoEfficiency[1];
+        else if ((E > fVetoEnergy[1]) && (E < fVetoEnergy[2])) Efficiency = fVetoEfficiency[2];
+        else if ((E > fVetoEnergy[2]) && (E < fVetoEnergy[3])) Efficiency = fVetoEfficiency[3];
+        else if (E > fVetoEnergy[3]) Efficiency = fVetoEfficiency[4];
+        if (pRandoms->Rndm() < Efficiency)
+        {
+          fPatternHits[0][nVetos] = elem;
+          nVetos++;
+        }
+      }
+
+    // Fill BaF2 information
+    fEnergy[elem] = E;
+    fEnergyOR[nBaF2s] = E;
+    if (fIsTime)
+    {
+      fTime[elem] = T;
+      fTimeOR[nBaF2s] = T;
+    }
+    fHits[nBaF2s] = elem;
+    total += E;
+    nBaF2s++;
+
+    //PSA - reasonable?
+    if(fMaxSGElements)
+    {
+      Bool_t IsBaF2 = true;
+      if ((fNelem == 402) && ((elem % 67) <  4)) IsBaF2 = false; // If 1 PbWO ring is installed, the first 4 crystals in a TAPS block are PbWO4s
+      if ((fNelem == 438) && ((elem % 73) < 12)) IsBaF2 = false; // If 2 PbWO rings are installed, the first 12 crystals in a TAPS block are PbWO4s
+
+      if (IsBaF2) // Do PSA information only for BaF2s
+      {
+        if ((elem == proton_crystal) || fCluster[elem]->IsNeighbour(proton_crystal)) // Hit in or neighbouring crystal best fitting to proton
+          //fSGEnergyValue[j] = E * TMath::Power(E, 0.05) * 0.65; //Sven's function
+          fSGEnergyValue[elem] = -0.9691614 + 0.7108238*E + 0.1819194e-2*E*E - 0.9019634e-5*E*E*E + 0.1610750e-7*E*E*E*E; //Marc's function
+      else
+          fSGEnergyValue[elem] = 0.96 * E;
+        fSGEnergyValue[elem] += pRandoms->Gaus(0.0, 0.25 * TMath::Sqrt(fSGEnergyValue[elem]));
+      }
+      else
+        fSGEnergyValue[elem] = E;
+    }
+
+  }
+
+  fHits[nBaF2s] = EBufferEnd;
+  fTimeOR[nBaF2s] = EBufferEnd;
+  fEnergyOR[nBaF2s] = EBufferEnd;
+  fNhits = nBaF2s;
+  fTotalEnergy = total;
+
+  if (fPatternHits)
+  {
+    fPatternHits[0][nVetos] = EBufferEnd;
+    fNPatternHits[0] = nVetos;
+    // Note, that this may conflict with other ReadDecoded() functions later on, as this destroys the venergy[]
+    // information! So, the bit pattern veto should not be used if another veto implementation is running!
+    memset(venergy, 0., fNelem*sizeof(Float_t));  // Need to cleanup, so that no data from previous event remains
+  }
+
+  if (fIsRawHits)
+  {
+    fRawEnergyHits[0] = EBufferEnd;
+    fRawTimeHits[0] = EBufferEnd;
+  }
+
+  bSimul = true;
 }
 
 //---------------------------------------------------------------------------

--- a/acqu_user/root/src/TA2TAPS_BaF2.h
+++ b/acqu_user/root/src/TA2TAPS_BaF2.h
@@ -345,7 +345,7 @@ inline void TA2TAPS_BaF2::ReadDecoded()
     if (fIsTime)
     {
       T = time[i] - fElement[elem]->GetT0() - fOffsetTime;
-      if (fTimeResolution > 0) T += pRandoms->Gaus(0.0, fTimeResolution);
+      if (fTimeResolution > 0 && fUseTimeResolution) T += pRandoms->Gaus(0.0, fTimeResolution);
 
       // check time thresholds
       if ((T < fElement[elem]->GetTimeLowThr()) ||


### PR DESCRIPTION
Added the ability to calibrate MC data the usual way within the CaLib package. Therefore we introduced the run number 0 for MC files. Example macros and configs for the initial setup were added as well. Prepared AcquRoot classes for applying calibrations to MC data. 

Changes include: 
- Removed unnecessary config keyword Scale-File from CB Cal Array class
- Terminate AcquRoot in case of unknown keywords
- Included possibility to apply MC calibrations in CB and TAPS ReadDecoded()
- Take care of time resolution config on/off behaviour which was ignored all the time
